### PR TITLE
Support variant-specific extras

### DIFF
--- a/admin/variant-options-page.php
+++ b/admin/variant-options-page.php
@@ -89,20 +89,23 @@ $variants = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}fede
 $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE category_id = %d AND active = 1 ORDER BY sort_order, name", $selected_category));
 $product_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'product' AND active = 1 ORDER BY sort_order, name", $selected_category));
 $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'frame' AND active = 1 ORDER BY sort_order, name", $selected_category));
+$extras = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_extras WHERE category_id = %d AND active = 1 ORDER BY sort_order, name", $selected_category));
 
 // Get all variant options with names (filtered by category)
 $variant_options = $wpdb->get_results($wpdb->prepare("
     SELECT vo.*, v.name as variant_name,
-           CASE 
+           CASE
                WHEN vo.option_type = 'condition' THEN c.name
                WHEN vo.option_type = 'product_color' THEN pc.name
                WHEN vo.option_type = 'frame_color' THEN fc.name
+               WHEN vo.option_type = 'extra' THEN e.name
            END as option_name
     FROM {$wpdb->prefix}federwiegen_variant_options vo
     LEFT JOIN {$wpdb->prefix}federwiegen_variants v ON vo.variant_id = v.id
     LEFT JOIN {$wpdb->prefix}federwiegen_conditions c ON vo.option_type = 'condition' AND vo.option_id = c.id
     LEFT JOIN {$wpdb->prefix}federwiegen_colors pc ON vo.option_type = 'product_color' AND vo.option_id = pc.id
     LEFT JOIN {$wpdb->prefix}federwiegen_colors fc ON vo.option_type = 'frame_color' AND vo.option_id = fc.id
+    LEFT JOIN {$wpdb->prefix}federwiegen_extras e ON vo.option_type = 'extra' AND vo.option_id = e.id
     WHERE v.category_id = %d
     ORDER BY v.name, vo.option_type, option_name
 ", $selected_category));
@@ -114,7 +117,7 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
         <div class="federwiegen-admin-logo-compact">🔗</div>
         <div class="federwiegen-admin-title-compact">
             <h1>Ausführungs-Optionen</h1>
-            <p>Zustände & Farben verknüpfen</p>
+            <p>Zustände, Farben & Extras verknüpfen</p>
         </div>
     </div>
     
@@ -183,7 +186,7 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                 ?>
                 <div class="federwiegen-tab-section">
                     <h3>🔗 Neue Zuordnung hinzufügen</h3>
-                    <p>Verknüpfen Sie Zustände und Farben mit spezifischen Ausführungen.</p>
+                    <p>Verknüpfen Sie Zustände, Farben und Extras mit spezifischen Ausführungen.</p>
                     
                     <div class="federwiegen-form-card">
                         <form method="post" action="">
@@ -214,6 +217,9 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                                         <?php if (!empty($frame_colors)): ?>
                                         <option value="frame_color">🖼️ Gestellfarbe</option>
                                         <?php endif; ?>
+                                        <?php if (!empty($extras)): ?>
+                                        <option value="extra">➕ Extra</option>
+                                        <?php endif; ?>
                                     </select>
                                 </div>
                                 
@@ -241,7 +247,7 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                 ?>
                 <div class="federwiegen-tab-section">
                     <h3>🔗 Zuordnung bearbeiten</h3>
-                    <p>Bearbeiten Sie die Verknüpfung zwischen Ausführung und Option.</p>
+                    <p>Bearbeiten Sie die Verknüpfung zwischen Ausführung und Option (Zustand/Farbe/Extra).</p>
                     
                     <div class="federwiegen-form-card">
                         <form method="post" action="">
@@ -274,6 +280,9 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                                         <?php if (!empty($frame_colors)): ?>
                                         <option value="frame_color" <?php selected($edit_item->option_type, 'frame_color'); ?>>🖼️ Gestellfarbe</option>
                                         <?php endif; ?>
+                                        <?php if (!empty($extras)): ?>
+                                        <option value="extra" <?php selected($edit_item->option_type, 'extra'); ?>>➕ Extra</option>
+                                        <?php endif; ?>
                                     </select>
                                 </div>
                                 
@@ -303,7 +312,7 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                 ?>
                 <div class="federwiegen-tab-section">
                     <h3>🔗 Ausführungs-Optionen</h3>
-                    <p>Verknüpfen Sie Zustände und Farben mit spezifischen Ausführungen.</p>
+                    <p>Verknüpfen Sie Zustände, Farben und Extras mit spezifischen Ausführungen.</p>
                     
                     <div class="federwiegen-list-card">
                         <h4>Zuordnungen für: <?php echo $current_category ? esc_html($current_category->name) : 'Unbekannte Kategorie'; ?></h4>
@@ -346,6 +355,9 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                                                     case 'frame_color':
                                                         echo '🖼️ ' . esc_html($option->option_name);
                                                         break;
+                                                    case 'extra':
+                                                        echo '➕ ' . esc_html($option->option_name);
+                                                        break;
                                                 }
                                                 ?>
                                             </strong>
@@ -375,6 +387,7 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
 const conditionsData = <?php echo json_encode($conditions); ?>;
 const productColorsData = <?php echo json_encode($product_colors); ?>;
 const frameColorsData = <?php echo json_encode($frame_colors); ?>;
+const extrasData = <?php echo json_encode($extras); ?>;
 const editItem = <?php echo json_encode($edit_item); ?>;
 
 function updateOptionsList() {
@@ -395,6 +408,9 @@ function updateOptionsList() {
             break;
         case 'frame_color':
             optionsData = frameColorsData;
+            break;
+        case 'extra':
+            optionsData = extrasData;
             break;
     }
     

--- a/assets/script.js
+++ b/assets/script.js
@@ -270,14 +270,19 @@ jQuery(document).ready(function($) {
                     
                     // Update product colors
                     updateOptionsDisplay('#product-color-section', '.federwiegen-options.product-colors', data.product_colors, 'product-color');
-                    
+
                     // Update frame colors
                     updateOptionsDisplay('#frame-color-section', '.federwiegen-options.frame-colors', data.frame_colors, 'frame-color');
-                    
+
+                    // Update extras
+                    updateOptionsDisplay('#extras-section', '.federwiegen-options.extras', data.extras, 'extra');
+
                     // Reset selections for variant-specific options
                     selectedCondition = null;
                     selectedProductColor = null;
                     selectedFrameColor = null;
+                    selectedExtras = [];
+                    updateExtraImage(null);
                     
                     updatePriceAndButton();
                 }
@@ -303,7 +308,7 @@ jQuery(document).ready(function($) {
             let optionHtml = '';
             
             if (optionType === 'condition') {
-                const badgeHtml = option.price_modifier != 0 ? 
+                const badgeHtml = option.price_modifier != 0 ?
                     `<span class="federwiegen-condition-badge">${option.price_modifier > 0 ? '+' : ''}${Math.round(option.price_modifier * 100)}%</span>` : '';
                 
                 optionHtml = `
@@ -330,6 +335,17 @@ jQuery(document).ready(function($) {
                         <div class="federwiegen-option-check">✓</div>
                     </div>
                 `;
+            } else if (optionType === 'extra') {
+                const priceHtml = option.price > 0 ? `+${parseFloat(option.price).toFixed(2).replace('.', ',')}€/Monat` : '';
+                optionHtml = `
+                    <div class="federwiegen-option" data-type="extra" data-id="${option.id}" data-extra-image="${option.image_url || ''}">
+                        <div class="federwiegen-option-content">
+                            <span class="federwiegen-extra-name">${option.name}</span>
+                            ${priceHtml ? `<div class="federwiegen-extra-price">${priceHtml}</div>` : ''}
+                        </div>
+                        <div class="federwiegen-option-check">✓</div>
+                    </div>
+                `;
             }
             
             container.append(optionHtml);
@@ -339,20 +355,27 @@ jQuery(document).ready(function($) {
         container.find('.federwiegen-option').on('click', function() {
             const type = $(this).data('type');
             const id = $(this).data('id');
-            
-            // Remove selection from same type
-            $(`.federwiegen-option[data-type="${type}"]`).removeClass('selected');
-            
-            // Add selection to clicked option
-            $(this).addClass('selected');
-            
-            // Update selection variables
-            if (type === 'condition') {
-                selectedCondition = id;
-            } else if (type === 'product-color') {
-                selectedProductColor = id;
-            } else if (type === 'frame-color') {
-                selectedFrameColor = id;
+
+            if (type === 'extra') {
+                $(this).toggleClass('selected');
+                const index = selectedExtras.indexOf(id);
+                if (index > -1) {
+                    selectedExtras.splice(index, 1);
+                } else {
+                    selectedExtras.push(id);
+                }
+                updateExtraImage($(this));
+            } else {
+                $(`.federwiegen-option[data-type="${type}"]`).removeClass('selected');
+                $(this).addClass('selected');
+
+                if (type === 'condition') {
+                    selectedCondition = id;
+                } else if (type === 'product-color') {
+                    selectedProductColor = id;
+                } else if (type === 'frame-color') {
+                    selectedFrameColor = id;
+                }
             }
             
             // Track interaction

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -213,6 +213,7 @@ class Ajax {
         $conditions = array();
         $product_colors = array();
         $frame_colors = array();
+        $extras = array();
         
         if (!empty($variant_options)) {
             // Get specific options for this variant
@@ -245,6 +246,15 @@ class Ajax {
                             $frame_colors[] = $color;
                         }
                         break;
+                    case 'extra':
+                        $extra = $wpdb->get_row($wpdb->prepare(
+                            "SELECT * FROM {$wpdb->prefix}federwiegen_extras WHERE id = %d AND active = 1",
+                            $option->option_id
+                        ));
+                        if ($extra) {
+                            $extras[] = $extra;
+                        }
+                        break;
                 }
             }
         } else {
@@ -269,13 +279,19 @@ class Ajax {
                     "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'frame' AND active = 1 AND available = 1 ORDER BY sort_order",
                     $variant->category_id
                 ));
+
+                $extras = $wpdb->get_results($wpdb->prepare(
+                    "SELECT * FROM {$wpdb->prefix}federwiegen_extras WHERE category_id = %d AND active = 1 ORDER BY sort_order",
+                    $variant->category_id
+                ));
             }
         }
-        
+
         wp_send_json_success(array(
             'conditions' => $conditions,
             'product_colors' => $product_colors,
-            'frame_colors' => $frame_colors
+            'frame_colors' => $frame_colors,
+            'extras' => $extras
         ));
     }
     

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -188,9 +188,9 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
 
                 <!-- Extras Selection -->
                 <?php if (!empty($extras)): ?>
-                <div class="federwiegen-section">
+                <div class="federwiegen-section" id="extras-section">
                     <h3>Wählen Sie Ihre Extras</h3>
-                    <div class="federwiegen-options extras layout-<?php echo esc_attr($layout_style); ?>">
+                    <div class="federwiegen-options extras layout-<?php echo esc_attr($layout_style); ?>" id="extras-container">
                         <?php foreach ($extras as $extra): ?>
                         <div class="federwiegen-option" data-type="extra" data-id="<?php echo esc_attr($extra->id); ?>"
                              data-extra-image="<?php echo esc_attr($extra->image_url ?? ''); ?>">


### PR DESCRIPTION
## Summary
- allow Extras to be linked to specific variants in admin
- extend AJAX endpoint and JS to load variant-specific extras
- update product page markup with ids for dynamic extras

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863064a32788330855bbd2da5fbfc73