### PR TITLE
Add toggle UI and availability control

### DIFF
--- a/admin/colors-page.php
+++ b/admin/colors-page.php
@@ -195,19 +195,8 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                                     <input type="number" name="sort_order" value="0" min="0">
                                 </div>
                                 
-                                <div class="federwiegen-form-group">
-                                    <label>
-                                        <input type="checkbox" name="available" value="1" checked>
-                                        Verfügbar
-                                    </label>
-                                </div>
-                                
-                                <div class="federwiegen-form-group">
-                                    <label>
-                                        <input type="checkbox" name="active" value="1" checked>
-                                        Aktiv
-                                    </label>
-                                </div>
+                                <input type="hidden" name="available" value="1">
+                                <input type="hidden" name="active" value="1">
                             </div>
                             
                             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">
@@ -258,19 +247,8 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                                     <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
                                 </div>
                                 
-                                <div class="federwiegen-form-group">
-                                    <label>
-                                        <input type="checkbox" name="available" value="1" <?php checked($edit_item->available); ?>>
-                                        Verfügbar
-                                    </label>
-                                </div>
-                                
-                                <div class="federwiegen-form-group">
-                                    <label>
-                                        <input type="checkbox" name="active" value="1" <?php checked($edit_item->active); ?>>
-                                        Aktiv
-                                    </label>
-                                </div>
+                                <input type="hidden" name="available" value="1">
+                                <input type="hidden" name="active" value="1">
                             </div>
                             
                             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">

--- a/admin/conditions-page.php
+++ b/admin/conditions-page.php
@@ -192,19 +192,8 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
                                     <input type="number" name="sort_order" value="0" min="0">
                                 </div>
                                 
-                                <div class="federwiegen-form-group">
-                                    <label>
-                                        <input type="checkbox" name="available" value="1" checked>
-                                        Verfügbar
-                                    </label>
-                                </div>
-                                
-                                <div class="federwiegen-form-group">
-                                    <label>
-                                        <input type="checkbox" name="active" value="1" checked>
-                                        Aktiv
-                                    </label>
-                                </div>
+                                <input type="hidden" name="available" value="1">
+                                <input type="hidden" name="active" value="1">
                             </div>
                             
                             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">
@@ -253,19 +242,8 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
                                     <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
                                 </div>
                                 
-                                <div class="federwiegen-form-group">
-                                    <label>
-                                        <input type="checkbox" name="available" value="1" <?php checked($edit_item->available); ?>>
-                                        Verfügbar
-                                    </label>
-                                </div>
-                                
-                                <div class="federwiegen-form-group">
-                                    <label>
-                                        <input type="checkbox" name="active" value="1" <?php checked($edit_item->active); ?>>
-                                        Aktiv
-                                    </label>
-                                </div>
+                                <input type="hidden" name="available" value="1">
+                                <input type="hidden" name="active" value="1">
                             </div>
                             
                             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">
@@ -318,9 +296,6 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
                                                 echo '<span style="color: #666;">±0%</span>';
                                             }
                                             ?>
-                                        </span>
-                                        <span class="federwiegen-status <?php echo $condition->available ? 'available' : 'unavailable'; ?>">
-                                            <?php echo $condition->available ? '✅ Verfügbar' : '❌ Nicht verfügbar'; ?>
                                         </span>
                                     </div>
                                 </div>

--- a/admin/tabs/categories-add-tab.php
+++ b/admin/tabs/categories-add-tab.php
@@ -153,12 +153,7 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" min="0">
                 </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" checked>
-                        <span>Aktiv</span>
-                    </label>
-                </div>
+                <input type="hidden" name="active" value="1">
             </div>
         </div>
         

--- a/admin/tabs/categories-edit-tab.php
+++ b/admin/tabs/categories-edit-tab.php
@@ -171,12 +171,7 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
                 </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" <?php echo $edit_item->active ? 'checked' : ''; ?>>
-                        <span>Aktiv</span>
-                    </label>
-                </div>
+                <input type="hidden" name="active" value="1">
             </div>
         </div>
         

--- a/admin/tabs/categories-list-tab.php
+++ b/admin/tabs/categories-list-tab.php
@@ -35,11 +35,6 @@
                 <?php endif; ?>
                 
                 <!-- Status Badge -->
-                <div class="federwiegen-category-status">
-                    <span class="federwiegen-status-badge <?php echo $category->active ? 'available' : 'unavailable'; ?>">
-                        <?php echo $category->active ? '✅ Aktiv' : '❌ Inaktiv'; ?>
-                    </span>
-                </div>
             </div>
             
             <div class="federwiegen-category-content">
@@ -151,11 +146,6 @@
     opacity: 0.5;
 }
 
-.federwiegen-category-status {
-    position: absolute;
-    top: 8px;
-    right: 8px;
-}
 
 .federwiegen-category-content {
     padding: 20px;

--- a/admin/tabs/colors-tab.php
+++ b/admin/tabs/colors-tab.php
@@ -158,11 +158,6 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                     <div class="federwiegen-color-info">
                         <h5><?php echo esc_html($color->name); ?></h5>
                         <code><?php echo esc_html($color->color_code); ?></code>
-                        <div class="federwiegen-color-status">
-                            <span class="federwiegen-status <?php echo $color->available ? 'available' : 'unavailable'; ?>">
-                                <?php echo $color->available ? '✅ Verfügbar' : '❌ Nicht verfügbar'; ?>
-                            </span>
-                        </div>
                     </div>
                     <div class="federwiegen-color-actions">
                         <a href="<?php echo admin_url('admin.php?page=federwiegen-products&category=' . $selected_category . '&tab=colors&edit_color=' . $color->id); ?>" class="button button-small">Bearbeiten</a>
@@ -192,11 +187,6 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                     <div class="federwiegen-color-info">
                         <h5><?php echo esc_html($color->name); ?></h5>
                         <code><?php echo esc_html($color->color_code); ?></code>
-                        <div class="federwiegen-color-status">
-                            <span class="federwiegen-status <?php echo $color->available ? 'available' : 'unavailable'; ?>">
-                                <?php echo $color->available ? '✅ Verfügbar' : '❌ Nicht verfügbar'; ?>
-                            </span>
-                        </div>
                     </div>
                     <div class="federwiegen-color-actions">
                         <a href="<?php echo admin_url('admin.php?page=federwiegen-products&category=' . $selected_category . '&tab=colors&edit_color=' . $color->id); ?>" class="button button-small">Bearbeiten</a>
@@ -266,9 +256,6 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
     margin-bottom: 10px;
 }
 
-.federwiegen-color-status {
-    margin-bottom: 15px;
-}
 
 .federwiegen-color-actions {
     display: flex;

--- a/admin/tabs/conditions-tab.php
+++ b/admin/tabs/conditions-tab.php
@@ -110,19 +110,8 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
                     <input type="number" name="sort_order" value="<?php echo $edit_item ? $edit_item->sort_order : '0'; ?>" min="0">
                 </div>
                 
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="available" value="1" <?php echo (!$edit_item || $edit_item->available) ? 'checked' : ''; ?>>
-                        Verfügbar
-                    </label>
-                </div>
-                
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="active" value="1" <?php echo (!$edit_item || $edit_item->active) ? 'checked' : ''; ?>>
-                        Aktiv
-                    </label>
-                </div>
+                <input type="hidden" name="available" value="1">
+                <input type="hidden" name="active" value="1">
             </div>
             
             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">
@@ -165,9 +154,6 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
                                 echo '<span style="color: #666;">±0%</span>';
                             }
                             ?>
-                        </span>
-                        <span class="federwiegen-status <?php echo $condition->available ? 'available' : 'unavailable'; ?>">
-                            <?php echo $condition->available ? '✅ Verfügbar' : '❌ Nicht verfügbar'; ?>
                         </span>
                     </div>
                 </div>

--- a/admin/tabs/durations-add-tab.php
+++ b/admin/tabs/durations-add-tab.php
@@ -42,12 +42,7 @@
         <!-- Einstellungen -->
         <div class="federwiegen-form-section">
             <h4>⚙️ Einstellungen</h4>
-            <div class="federwiegen-form-group">
-                <label class="federwiegen-checkbox-label">
-                    <input type="checkbox" name="active" value="1" checked>
-                    <span>Aktiv</span>
-                </label>
-            </div>
+            <input type="hidden" name="active" value="1">
         </div>
         
         <!-- Actions -->

--- a/admin/tabs/durations-edit-tab.php
+++ b/admin/tabs/durations-edit-tab.php
@@ -43,12 +43,7 @@
         <!-- Einstellungen -->
         <div class="federwiegen-form-section">
             <h4>⚙️ Einstellungen</h4>
-            <div class="federwiegen-form-group">
-                <label class="federwiegen-checkbox-label">
-                    <input type="checkbox" name="active" value="1" <?php echo $edit_item->active ? 'checked' : ''; ?>>
-                    <span>Aktiv</span>
-                </label>
-            </div>
+            <input type="hidden" name="active" value="1">
         </div>
         
         <!-- Actions -->

--- a/admin/tabs/durations-list-tab.php
+++ b/admin/tabs/durations-list-tab.php
@@ -52,11 +52,6 @@
                         <small>Sortierung: <?php echo $duration->sort_order; ?></small>
                     </div>
                     
-                    <div class="federwiegen-duration-status">
-                        <span class="federwiegen-status-badge <?php echo $duration->active ? 'available' : 'unavailable'; ?>">
-                            <?php echo $duration->active ? '✅ Aktiv' : '❌ Inaktiv'; ?>
-                        </span>
-                    </div>
                 </div>
                 
                 <div class="federwiegen-duration-actions">

--- a/admin/tabs/durations-tab.php
+++ b/admin/tabs/durations-tab.php
@@ -153,9 +153,6 @@ $durations = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE 
                         <?php if ($duration->discount > 0): ?>
                             <span class="federwiegen-discount-badge">-<?php echo round($duration->discount * 100); ?>% Rabatt</span>
                         <?php endif; ?>
-                        <span class="federwiegen-status <?php echo $duration->active ? 'available' : 'unavailable'; ?>">
-                            <?php echo $duration->active ? '✅ Aktiv' : '❌ Inaktiv'; ?>
-                        </span>
                     </div>
                 </div>
                 

--- a/admin/tabs/extras-add-tab.php
+++ b/admin/tabs/extras-add-tab.php
@@ -48,12 +48,7 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" value="0" min="0">
                 </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" checked>
-                        <span>Aktiv</span>
-                    </label>
-                </div>
+                <input type="hidden" name="active" value="1">
             </div>
         </div>
         

--- a/admin/tabs/extras-edit-tab.php
+++ b/admin/tabs/extras-edit-tab.php
@@ -55,12 +55,7 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
                 </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" <?php echo $edit_item->active ? 'checked' : ''; ?>>
-                        <span>Aktiv</span>
-                    </label>
-                </div>
+                <input type="hidden" name="active" value="1">
             </div>
         </div>
         

--- a/admin/tabs/extras-list-tab.php
+++ b/admin/tabs/extras-list-tab.php
@@ -37,12 +37,6 @@
                     </div>
                 <?php endif; ?>
                 
-                <!-- Status Badge -->
-                <div class="federwiegen-extra-status">
-                    <span class="federwiegen-status-badge <?php echo $extra->active ? 'available' : 'unavailable'; ?>">
-                        <?php echo $extra->active ? '✅ Aktiv' : '❌ Inaktiv'; ?>
-                    </span>
-                </div>
             </div>
             
             <div class="federwiegen-extra-content">
@@ -146,11 +140,6 @@
     opacity: 0.5;
 }
 
-.federwiegen-extra-status {
-    position: absolute;
-    top: 8px;
-    right: 8px;
-}
 
 .federwiegen-extra-content {
     padding: 20px;

--- a/admin/tabs/extras-tab.php
+++ b/admin/tabs/extras-tab.php
@@ -163,9 +163,6 @@ $extras = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE cat
                     <h5><?php echo esc_html($extra->name); ?></h5>
                     <div class="federwiegen-item-meta">
                         <span class="federwiegen-price"><?php echo number_format($extra->price, 2, ',', '.'); ?>€</span>
-                        <span class="federwiegen-status <?php echo $extra->active ? 'available' : 'unavailable'; ?>">
-                            <?php echo $extra->active ? '✅ Aktiv' : '❌ Inaktiv'; ?>
-                        </span>
                     </div>
                 </div>
                 

--- a/admin/tabs/variants-add-tab.php
+++ b/admin/tabs/variants-add-tab.php
@@ -41,9 +41,10 @@
             <h4>📦 Verfügbarkeit</h4>
             <div class="federwiegen-form-row">
                 <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
+                    <label>Verfügbar</label>
+                    <label class="fw-toggle">
                         <input type="checkbox" name="available" value="1" checked>
-                        <span>Verfügbar</span>
+                        <span></span>
                     </label>
                 </div>
                 <div class="federwiegen-form-group">
@@ -79,12 +80,7 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" value="0" min="0">
                 </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" checked>
-                        <span>Aktiv</span>
-                    </label>
-                </div>
+                <input type="hidden" name="active" value="1">
             </div>
         </div>
         

--- a/admin/tabs/variants-edit-tab.php
+++ b/admin/tabs/variants-edit-tab.php
@@ -42,9 +42,10 @@
             <h4>📦 Verfügbarkeit</h4>
             <div class="federwiegen-form-row">
                 <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
+                    <label>Verfügbar</label>
+                    <label class="fw-toggle">
                         <input type="checkbox" name="available" value="1" <?php echo ($edit_item->available ?? 1) ? 'checked' : ''; ?>>
-                        <span>Verfügbar</span>
+                        <span></span>
                     </label>
                 </div>
                 <div class="federwiegen-form-group">
@@ -86,12 +87,7 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
                 </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" <?php echo $edit_item->active ? 'checked' : ''; ?>>
-                        <span>Aktiv</span>
-                    </label>
-                </div>
+                <input type="hidden" name="active" value="1">
             </div>
         </div>
         

--- a/admin/variant-options-page.php
+++ b/admin/variant-options-page.php
@@ -23,6 +23,7 @@ if (isset($_POST['submit'])) {
     $variant_id = intval($_POST['variant_id']);
     $option_type = sanitize_text_field($_POST['option_type']);
     $option_id = intval($_POST['option_id']);
+    $available = isset($_POST['available']) ? 1 : 0;
 
     $table_name = $wpdb->prefix . 'federwiegen_variant_options';
 
@@ -33,10 +34,11 @@ if (isset($_POST['submit'])) {
             array(
                 'variant_id' => $variant_id,
                 'option_type' => $option_type,
-                'option_id' => $option_id
+                'option_id' => $option_id,
+                'available' => $available
             ),
             array('id' => intval($_POST['id'])),
-            array('%d', '%s', '%d'),
+            array('%d', '%s', '%d', '%d'),
             array('%d')
         );
         
@@ -52,9 +54,10 @@ if (isset($_POST['submit'])) {
             array(
                 'variant_id' => $variant_id,
                 'option_type' => $option_type,
-                'option_id' => $option_id
+                'option_id' => $option_id,
+                'available' => $available
             ),
-            array('%d', '%s', '%d')
+            array('%d', '%s', '%d', '%d')
         );
         
         if ($result !== false) {
@@ -229,6 +232,14 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                                         <option value="">Erst Option-Typ wählen...</option>
                                     </select>
                                 </div>
+
+                                <div class="federwiegen-form-group">
+                                    <label>Verfügbar</label>
+                                    <label class="fw-toggle">
+                                        <input type="checkbox" name="available" value="1" checked>
+                                        <span></span>
+                                    </label>
+                                </div>
                             </div>
                             
                             <div class="federwiegen-form-actions">
@@ -291,6 +302,14 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                                     <select name="option_id" id="option_id" required>
                                         <option value="">Erst Option-Typ wählen...</option>
                                     </select>
+                                </div>
+
+                                <div class="federwiegen-form-group">
+                                    <label>Verfügbar</label>
+                                    <label class="fw-toggle">
+                                        <input type="checkbox" name="available" value="1" <?php echo $edit_item->available ? 'checked' : ''; ?>>
+                                        <span></span>
+                                    </label>
                                 </div>
                             </div>
                             
@@ -361,6 +380,9 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                                                 }
                                                 ?>
                                             </strong>
+                                            <?php if (!$option->available): ?>
+                                                <span style="color: #dc3545; margin-left: 6px;">(nicht verfügbar)</span>
+                                            <?php endif; ?>
                                         </div>
                                         <div style="display: flex; gap: 5px;">
                                             <a href="<?php echo admin_url('admin.php?page=federwiegen-variant-options&category=' . $selected_category . '&tab=edit&edit=' . $option->id); ?>" class="button button-small">✏️</a>

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -323,6 +323,47 @@
     margin-right: 8px;
 }
 
+/* Toggle style */
+.fw-toggle {
+    position: relative;
+    display: inline-block;
+    width: 44px;
+    height: 24px;
+}
+.fw-toggle input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+.fw-toggle span {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    transition: .2s;
+    border-radius: 24px;
+}
+.fw-toggle span:before {
+    position: absolute;
+    content: '';
+    height: 18px;
+    width: 18px;
+    left: 3px;
+    bottom: 3px;
+    background-color: white;
+    transition: .2s;
+    border-radius: 50%;
+}
+.fw-toggle input:checked + span {
+    background-color: #4a674a;
+}
+.fw-toggle input:checked + span:before {
+    transform: translateX(20px);
+}
+
 .federwiegen-form-group small {
     margin-top: 5px;
     color: #666;
@@ -461,6 +502,11 @@
 .federwiegen-status.unavailable {
     color: #dc3232;
     font-size: 12px;
+}
+
+.federwiegen-unavailable-badge {
+    color: #dc3232;
+    margin-left: 6px;
 }
 
 .federwiegen-item-actions {

--- a/assets/script.js
+++ b/assets/script.js
@@ -27,9 +27,9 @@ jQuery(document).ready(function($) {
         const type = $(this).data('type');
         const id = $(this).data('id');
 
-        // Check if variant is available
-        if (type === 'variant' && $(this).data('available') === 'false') {
-            return; // Don't allow selection of unavailable variants
+        const avail = $(this).data('available');
+        if (avail === 'false') {
+            return;
         }
 
         // Remove selection from same type (except extras which allow multiple)
@@ -307,12 +307,13 @@ jQuery(document).ready(function($) {
         options.forEach(function(option) {
             let optionHtml = '';
             
+            const availAttr = option.available ? 'true' : 'false';
             if (optionType === 'condition') {
                 const badgeHtml = option.price_modifier != 0 ?
                     `<span class="federwiegen-condition-badge">${option.price_modifier > 0 ? '+' : ''}${Math.round(option.price_modifier * 100)}%</span>` : '';
-                
+
                 optionHtml = `
-                    <div class="federwiegen-option" data-type="condition" data-id="${option.id}">
+                    <div class="federwiegen-option" data-type="condition" data-id="${option.id}" data-available="${availAttr}">
                         <div class="federwiegen-option-content">
                             <div class="federwiegen-condition-header">
                                 <span class="federwiegen-condition-name">${option.name}</span>
@@ -321,11 +322,12 @@ jQuery(document).ready(function($) {
                             <p class="federwiegen-condition-info">${option.description}</p>
                         </div>
                         <div class="federwiegen-option-check">✓</div>
+                        ${option.available ? '' : '<span class="federwiegen-unavailable-badge">❌</span>'}
                     </div>
                 `;
             } else if (optionType === 'product-color' || optionType === 'frame-color') {
                 optionHtml = `
-                    <div class="federwiegen-option" data-type="${optionType}" data-id="${option.id}">
+                    <div class="federwiegen-option" data-type="${optionType}" data-id="${option.id}" data-available="${availAttr}">
                         <div class="federwiegen-option-content">
                             <div class="federwiegen-color-display">
                                 <div class="federwiegen-color-preview" style="background-color: ${option.color_code};"></div>
@@ -333,17 +335,19 @@ jQuery(document).ready(function($) {
                             </div>
                         </div>
                         <div class="federwiegen-option-check">✓</div>
+                        ${option.available ? '' : '<span class="federwiegen-unavailable-badge">❌</span>'}
                     </div>
                 `;
             } else if (optionType === 'extra') {
                 const priceHtml = option.price > 0 ? `+${parseFloat(option.price).toFixed(2).replace('.', ',')}€/Monat` : '';
                 optionHtml = `
-                    <div class="federwiegen-option" data-type="extra" data-id="${option.id}" data-extra-image="${option.image_url || ''}">
+                    <div class="federwiegen-option" data-type="extra" data-id="${option.id}" data-extra-image="${option.image_url || ''}" data-available="${availAttr}">
                         <div class="federwiegen-option-content">
                             <span class="federwiegen-extra-name">${option.name}</span>
                             ${priceHtml ? `<div class="federwiegen-extra-price">${priceHtml}</div>` : ''}
                         </div>
                         <div class="federwiegen-option-check">✓</div>
+                        ${option.available ? '' : '<span class="federwiegen-unavailable-badge">❌</span>'}
                     </div>
                 `;
             }
@@ -355,6 +359,7 @@ jQuery(document).ready(function($) {
         container.find('.federwiegen-option').on('click', function() {
             const type = $(this).data('type');
             const id = $(this).data('id');
+            if ($(this).data('available') === 'false') return;
 
             if (type === 'extra') {
                 $(this).toggleClass('selected');

--- a/federwiegen-verleih.php
+++ b/federwiegen-verleih.php
@@ -3,7 +3,7 @@
   * Plugin Name: Rent Plugin
   * Plugin URI: https://h2concepts.de
   * Description: Ein Plugin für den Verleih von Waren mit konfigurierbaren Produkten und Stripe-Integration
-  * Version: 2.0.0
+ * Version: 2.1.0
   * Author: H2 Concepts
   * License: GPL v2 or later
   * Text Domain: h2-concepts
@@ -14,7 +14,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-const FEDERWIEGEN_PLUGIN_VERSION = '2.0.0';
+const FEDERWIEGEN_PLUGIN_VERSION = '2.1.0';
 const FEDERWIEGEN_PLUGIN_DIR = __DIR__ . '/';
 define('FEDERWIEGEN_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('FEDERWIEGEN_PLUGIN_PATH', FEDERWIEGEN_PLUGIN_DIR);

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -206,7 +206,7 @@ class Ajax {
         
         // Get variant-specific options
         $variant_options = $wpdb->get_results($wpdb->prepare(
-            "SELECT option_type, option_id FROM {$wpdb->prefix}federwiegen_variant_options WHERE variant_id = %d",
+            "SELECT option_type, option_id, available FROM {$wpdb->prefix}federwiegen_variant_options WHERE variant_id = %d",
             $variant_id
         ));
         
@@ -225,6 +225,7 @@ class Ajax {
                             $option->option_id
                         ));
                         if ($condition) {
+                            $condition->available = (bool)$option->available;
                             $conditions[] = $condition;
                         }
                         break;
@@ -234,6 +235,7 @@ class Ajax {
                             $option->option_id
                         ));
                         if ($color) {
+                            $color->available = (bool)$option->available;
                             $product_colors[] = $color;
                         }
                         break;
@@ -243,6 +245,7 @@ class Ajax {
                             $option->option_id
                         ));
                         if ($color) {
+                            $color->available = (bool)$option->available;
                             $frame_colors[] = $color;
                         }
                         break;
@@ -252,6 +255,7 @@ class Ajax {
                             $option->option_id
                         ));
                         if ($extra) {
+                            $extra->available = (bool)$option->available;
                             $extras[] = $extra;
                         }
                         break;
@@ -269,21 +273,25 @@ class Ajax {
                     "SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE category_id = %d AND active = 1 AND available = 1 ORDER BY sort_order",
                     $variant->category_id
                 ));
-                
+                foreach ($conditions as $c) { $c->available = true; }
+
                 $product_colors = $wpdb->get_results($wpdb->prepare(
                     "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'product' AND active = 1 AND available = 1 ORDER BY sort_order",
                     $variant->category_id
                 ));
-                
+                foreach ($product_colors as $c) { $c->available = true; }
+
                 $frame_colors = $wpdb->get_results($wpdb->prepare(
                     "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'frame' AND active = 1 AND available = 1 ORDER BY sort_order",
                     $variant->category_id
                 ));
+                foreach ($frame_colors as $c) { $c->available = true; }
 
                 $extras = $wpdb->get_results($wpdb->prepare(
                     "SELECT * FROM {$wpdb->prefix}federwiegen_extras WHERE category_id = %d AND active = 1 ORDER BY sort_order",
                     $variant->category_id
                 ));
+                foreach ($extras as $e) { $e->available = true; }
             }
         }
 

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -266,12 +266,18 @@ class Database {
                 variant_id mediumint(9) NOT NULL,
                 option_type varchar(50) NOT NULL,
                 option_id mediumint(9) NOT NULL,
+                available tinyint(1) DEFAULT 1,
                 PRIMARY KEY (id),
                 UNIQUE KEY variant_option (variant_id, option_type, option_id)
             ) $charset_collate;";
-            
+
             require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
             dbDelta($sql);
+        } else {
+            $column_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_variant_options LIKE 'available'");
+            if (empty($column_exists)) {
+                $wpdb->query("ALTER TABLE $table_variant_options ADD COLUMN available TINYINT(1) DEFAULT 1 AFTER option_id");
+            }
         }
         
         // Create orders table if it doesn't exist
@@ -503,6 +509,7 @@ class Database {
             variant_id mediumint(9) NOT NULL,
             option_type varchar(50) NOT NULL,
             option_id mediumint(9) NOT NULL,
+            available tinyint(1) DEFAULT 1,
             PRIMARY KEY (id),
             UNIQUE KEY variant_option (variant_id, option_type, option_id)
         ) $charset_collate;";


### PR DESCRIPTION
## Summary
- implement toggle CSS
- add availability field to variant option database
- add availability toggle to variant options UI
- replace active/available checkboxes with hidden defaults on other admin forms
- update front-end JS to respect availability and show badges
- remove active indicators from admin lists
- bump plugin version to trigger database update

## Testing
- `php -l admin/variant-options-page.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6863a3f248888330a5a278f02caf2e0b