### PR TITLE
Remove legacy active flags and add variant option availability

### DIFF
--- a/admin/colors-page.php
+++ b/admin/colors-page.php
@@ -22,8 +22,8 @@ if (isset($_POST['submit'])) {
     $name = sanitize_text_field($_POST['name']);
     $color_code = sanitize_hex_color($_POST['color_code']);
     $color_type = sanitize_text_field($_POST['color_type']);
-    $available = isset($_POST['available']) ? 1 : 0;
-    $active = isset($_POST['active']) ? 1 : 0;
+    $available = 1;
+    $active = 1;
     $sort_order = intval($_POST['sort_order']);
 
     if (isset($_POST['id']) && $_POST['id']) {
@@ -35,12 +35,10 @@ if (isset($_POST['submit'])) {
                 'name' => $name,
                 'color_code' => $color_code,
                 'color_type' => $color_type,
-                'available' => $available,
-                'active' => $active,
                 'sort_order' => $sort_order
             ),
             array('id' => intval($_POST['id'])),
-            array('%d', '%s', '%s', '%s', '%d', '%d', '%d'),
+            array('%d', '%s', '%s', '%s', '%d'),
             array('%d')
         );
         
@@ -58,11 +56,9 @@ if (isset($_POST['submit'])) {
                 'name' => $name,
                 'color_code' => $color_code,
                 'color_type' => $color_type,
-                'available' => $available,
-                'active' => $active,
                 'sort_order' => $sort_order
             ),
-            array('%d', '%s', '%s', '%s', '%d', '%d', '%d')
+            array('%d', '%s', '%s', '%s', '%d')
         );
         
         if ($result !== false) {
@@ -195,7 +191,6 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                                     <input type="number" name="sort_order" value="0" min="0">
                                 </div>
                                 
-
                             </div>
                             
                             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">
@@ -245,7 +240,6 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                                     <label>Sortierung</label>
                                     <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
                                 </div>
-                                
 
                             </div>
                             
@@ -292,11 +286,6 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                                             <code style="font-size: 12px;"><?php echo esc_html($color->color_code); ?></code>
                                         </div>
                                     </div>
-                                    <div class="federwiegen-item-meta">
-                                        <span class="federwiegen-status <?php echo $color->available ? 'available' : 'unavailable'; ?>">
-                                            <?php echo $color->available ? '✅ Verfügbar' : '❌ Nicht verfügbar'; ?>
-                                        </span>
-                                    </div>
                                 </div>
                                 
                                 <div class="federwiegen-item-actions">
@@ -330,11 +319,6 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                                             <h5 style="margin: 0;"><?php echo esc_html($color->name); ?></h5>
                                             <code style="font-size: 12px;"><?php echo esc_html($color->color_code); ?></code>
                                         </div>
-                                    </div>
-                                    <div class="federwiegen-item-meta">
-                                        <span class="federwiegen-status <?php echo $color->available ? 'available' : 'unavailable'; ?>">
-                                            <?php echo $color->available ? '✅ Verfügbar' : '❌ Nicht verfügbar'; ?>
-                                        </span>
                                     </div>
                                 </div>
                                 

--- a/admin/colors-page.php
+++ b/admin/colors-page.php
@@ -195,19 +195,7 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                                     <input type="number" name="sort_order" value="0" min="0">
                                 </div>
                                 
-                                <div class="federwiegen-form-group">
-                                    <label>
-                                        <input type="checkbox" name="available" value="1" checked>
-                                        Verfügbar
-                                    </label>
-                                </div>
-                                
-                                <div class="federwiegen-form-group">
-                                    <label>
-                                        <input type="checkbox" name="active" value="1" checked>
-                                        Aktiv
-                                    </label>
-                                </div>
+
                             </div>
                             
                             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">
@@ -258,19 +246,7 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                                     <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
                                 </div>
                                 
-                                <div class="federwiegen-form-group">
-                                    <label>
-                                        <input type="checkbox" name="available" value="1" <?php checked($edit_item->available); ?>>
-                                        Verfügbar
-                                    </label>
-                                </div>
-                                
-                                <div class="federwiegen-form-group">
-                                    <label>
-                                        <input type="checkbox" name="active" value="1" <?php checked($edit_item->active); ?>>
-                                        Aktiv
-                                    </label>
-                                </div>
+
                             </div>
                             
                             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">

--- a/admin/conditions-page.php
+++ b/admin/conditions-page.php
@@ -22,8 +22,8 @@ if (isset($_POST['submit'])) {
     $name = sanitize_text_field($_POST['name']);
     $description = sanitize_textarea_field($_POST['description']);
     $price_modifier = floatval($_POST['price_modifier']) / 100; // Convert percentage to decimal
-    $available = isset($_POST['available']) ? 1 : 0;
-    $active = isset($_POST['active']) ? 1 : 0;
+    $available = 1;
+    $active = 1;
     $sort_order = intval($_POST['sort_order']);
 
     if (isset($_POST['id']) && $_POST['id']) {
@@ -35,12 +35,10 @@ if (isset($_POST['submit'])) {
                 'name' => $name,
                 'description' => $description,
                 'price_modifier' => $price_modifier,
-                'available' => $available,
-                'active' => $active,
                 'sort_order' => $sort_order
             ),
             array('id' => intval($_POST['id'])),
-            array('%d', '%s', '%s', '%f', '%d', '%d', '%d'),
+            ('%d', '%s', '%s', '%f', '%d'),
             array('%d')
         );
         
@@ -58,11 +56,9 @@ if (isset($_POST['submit'])) {
                 'name' => $name,
                 'description' => $description,
                 'price_modifier' => $price_modifier,
-                'available' => $available,
-                'active' => $active,
                 'sort_order' => $sort_order
             ),
-            array('%d', '%s', '%s', '%f', '%d', '%d', '%d')
+             array('%d', '%s', '%s', '%f', '%d')
         );
         
         if ($result !== false) {
@@ -191,7 +187,6 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
                                     <label>Sortierung</label>
                                     <input type="number" name="sort_order" value="0" min="0">
                                 </div>
-                                
 
                             </div>
                             
@@ -240,7 +235,6 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
                                     <label>Sortierung</label>
                                     <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
                                 </div>
-                                
 
                             </div>
                             
@@ -294,9 +288,6 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
                                                 echo '<span style="color: #666;">±0%</span>';
                                             }
                                             ?>
-                                        </span>
-                                        <span class="federwiegen-status <?php echo $condition->available ? 'available' : 'unavailable'; ?>">
-                                            <?php echo $condition->available ? '✅ Verfügbar' : '❌ Nicht verfügbar'; ?>
                                         </span>
                                     </div>
                                 </div>

--- a/admin/conditions-page.php
+++ b/admin/conditions-page.php
@@ -192,19 +192,7 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
                                     <input type="number" name="sort_order" value="0" min="0">
                                 </div>
                                 
-                                <div class="federwiegen-form-group">
-                                    <label>
-                                        <input type="checkbox" name="available" value="1" checked>
-                                        Verfügbar
-                                    </label>
-                                </div>
-                                
-                                <div class="federwiegen-form-group">
-                                    <label>
-                                        <input type="checkbox" name="active" value="1" checked>
-                                        Aktiv
-                                    </label>
-                                </div>
+
                             </div>
                             
                             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">
@@ -253,19 +241,7 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
                                     <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
                                 </div>
                                 
-                                <div class="federwiegen-form-group">
-                                    <label>
-                                        <input type="checkbox" name="available" value="1" <?php checked($edit_item->available); ?>>
-                                        Verfügbar
-                                    </label>
-                                </div>
-                                
-                                <div class="federwiegen-form-group">
-                                    <label>
-                                        <input type="checkbox" name="active" value="1" <?php checked($edit_item->active); ?>>
-                                        Aktiv
-                                    </label>
-                                </div>
+
                             </div>
                             
                             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">

--- a/admin/tabs/categories-add-tab.php
+++ b/admin/tabs/categories-add-tab.php
@@ -153,12 +153,6 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" min="0">
                 </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" checked>
-                        <span>Aktiv</span>
-                    </label>
-                </div>
             </div>
         </div>
         

--- a/admin/tabs/categories-edit-tab.php
+++ b/admin/tabs/categories-edit-tab.php
@@ -171,12 +171,6 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
                 </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" <?php echo $edit_item->active ? 'checked' : ''; ?>>
-                        <span>Aktiv</span>
-                    </label>
-                </div>
             </div>
         </div>
         

--- a/admin/tabs/categories-list-tab.php
+++ b/admin/tabs/categories-list-tab.php
@@ -34,12 +34,7 @@
                     </div>
                 <?php endif; ?>
                 
-                <!-- Status Badge -->
-                <div class="federwiegen-category-status">
-                    <span class="federwiegen-status-badge <?php echo $category->active ? 'available' : 'unavailable'; ?>">
-                        <?php echo $category->active ? '✅ Aktiv' : '❌ Inaktiv'; ?>
-                    </span>
-                </div>
+
             </div>
             
             <div class="federwiegen-category-content">

--- a/admin/tabs/colors-tab.php
+++ b/admin/tabs/colors-tab.php
@@ -8,8 +8,8 @@ if (isset($_POST['submit_color'])) {
     $name = sanitize_text_field($_POST['name']);
     $color_code = sanitize_hex_color($_POST['color_code']);
     $color_type = sanitize_text_field($_POST['color_type']);
-    $available = isset($_POST['available']) ? 1 : 0;
-    $active = isset($_POST['active']) ? 1 : 0;
+    $available = 1;
+    $active = 1;
     $sort_order = intval($_POST['sort_order']);
 
     if (isset($_POST['id']) && $_POST['id']) {
@@ -22,11 +22,10 @@ if (isset($_POST['submit_color'])) {
                 'color_code' => $color_code,
                 'color_type' => $color_type,
                 'available' => $available,
-                'active' => $active,
                 'sort_order' => $sort_order
             ),
             array('id' => intval($_POST['id'])),
-            array('%d', '%s', '%s', '%s', '%d', '%d', '%d'),
+            array('%d', '%s', '%s', '%s', '%d'),
             array('%d')
         );
         
@@ -43,10 +42,9 @@ if (isset($_POST['submit_color'])) {
                 'color_code' => $color_code,
                 'color_type' => $color_type,
                 'available' => $available,
-                'active' => $active,
                 'sort_order' => $sort_order
             ),
-            array('%d', '%s', '%s', '%s', '%d', '%d', '%d')
+            array('%d', '%s', '%s', '%s', '%d')
         );
         
         if ($result !== false) {
@@ -113,19 +111,7 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                     <input type="number" name="sort_order" value="<?php echo $edit_item ? $edit_item->sort_order : '0'; ?>" min="0">
                 </div>
                 
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="available" value="1" <?php echo (!$edit_item || $edit_item->available) ? 'checked' : ''; ?>>
-                        Verfügbar
-                    </label>
-                </div>
                 
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="active" value="1" <?php echo (!$edit_item || $edit_item->active) ? 'checked' : ''; ?>>
-                        Aktiv
-                    </label>
-                </div>
             </div>
             
             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">

--- a/admin/tabs/conditions-tab.php
+++ b/admin/tabs/conditions-tab.php
@@ -8,8 +8,8 @@ if (isset($_POST['submit_condition'])) {
     $name = sanitize_text_field($_POST['name']);
     $description = sanitize_textarea_field($_POST['description']);
     $price_modifier = floatval($_POST['price_modifier']) / 100; // Convert percentage to decimal
-    $available = isset($_POST['available']) ? 1 : 0;
-    $active = isset($_POST['active']) ? 1 : 0;
+    $available = 1;
+    $active = 1;
     $sort_order = intval($_POST['sort_order']);
 
     if (isset($_POST['id']) && $_POST['id']) {
@@ -22,11 +22,10 @@ if (isset($_POST['submit_condition'])) {
                 'description' => $description,
                 'price_modifier' => $price_modifier,
                 'available' => $available,
-                'active' => $active,
                 'sort_order' => $sort_order
             ),
             array('id' => intval($_POST['id'])),
-            array('%d', '%s', '%s', '%f', '%d', '%d', '%d'),
+            array('%d', '%s', '%s', '%f', '%d'),
             array('%d')
         );
         
@@ -43,10 +42,9 @@ if (isset($_POST['submit_condition'])) {
                 'description' => $description,
                 'price_modifier' => $price_modifier,
                 'available' => $available,
-                'active' => $active,
                 'sort_order' => $sort_order
             ),
-            array('%d', '%s', '%s', '%f', '%d', '%d', '%d')
+            array('%d', '%s', '%s', '%f', '%d')
         );
         
         if ($result !== false) {
@@ -110,19 +108,7 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
                     <input type="number" name="sort_order" value="<?php echo $edit_item ? $edit_item->sort_order : '0'; ?>" min="0">
                 </div>
                 
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="available" value="1" <?php echo (!$edit_item || $edit_item->available) ? 'checked' : ''; ?>>
-                        Verfügbar
-                    </label>
-                </div>
-                
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="active" value="1" <?php echo (!$edit_item || $edit_item->active) ? 'checked' : ''; ?>>
-                        Aktiv
-                    </label>
-                </div>
+
             </div>
             
             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">

--- a/admin/tabs/durations-add-tab.php
+++ b/admin/tabs/durations-add-tab.php
@@ -42,12 +42,7 @@
         <!-- Einstellungen -->
         <div class="federwiegen-form-section">
             <h4>⚙️ Einstellungen</h4>
-            <div class="federwiegen-form-group">
-                <label class="federwiegen-checkbox-label">
-                    <input type="checkbox" name="active" value="1" checked>
-                    <span>Aktiv</span>
-                </label>
-            </div>
+
         </div>
         
         <!-- Actions -->

--- a/admin/tabs/durations-edit-tab.php
+++ b/admin/tabs/durations-edit-tab.php
@@ -43,12 +43,7 @@
         <!-- Einstellungen -->
         <div class="federwiegen-form-section">
             <h4>⚙️ Einstellungen</h4>
-            <div class="federwiegen-form-group">
-                <label class="federwiegen-checkbox-label">
-                    <input type="checkbox" name="active" value="1" <?php echo $edit_item->active ? 'checked' : ''; ?>>
-                    <span>Aktiv</span>
-                </label>
-            </div>
+
         </div>
         
         <!-- Actions -->

--- a/admin/tabs/durations-list-tab.php
+++ b/admin/tabs/durations-list-tab.php
@@ -52,11 +52,7 @@
                         <small>Sortierung: <?php echo $duration->sort_order; ?></small>
                     </div>
                     
-                    <div class="federwiegen-duration-status">
-                        <span class="federwiegen-status-badge <?php echo $duration->active ? 'available' : 'unavailable'; ?>">
-                            <?php echo $duration->active ? '✅ Aktiv' : '❌ Inaktiv'; ?>
-                        </span>
-                    </div>
+
                 </div>
                 
                 <div class="federwiegen-duration-actions">

--- a/admin/tabs/durations-tab.php
+++ b/admin/tabs/durations-tab.php
@@ -113,12 +113,7 @@ $durations = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE 
                     <input type="number" name="sort_order" value="<?php echo $edit_item ? $edit_item->sort_order : '0'; ?>" min="0">
                 </div>
                 
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="active" value="1" <?php echo (!$edit_item || $edit_item->active) ? 'checked' : ''; ?>>
-                        Aktiv
-                    </label>
-                </div>
+
             </div>
             
             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">

--- a/admin/tabs/extras-add-tab.php
+++ b/admin/tabs/extras-add-tab.php
@@ -48,12 +48,7 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" value="0" min="0">
                 </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" checked>
-                        <span>Aktiv</span>
-                    </label>
-                </div>
+
             </div>
         </div>
         

--- a/admin/tabs/extras-edit-tab.php
+++ b/admin/tabs/extras-edit-tab.php
@@ -55,12 +55,7 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
                 </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" <?php echo $edit_item->active ? 'checked' : ''; ?>>
-                        <span>Aktiv</span>
-                    </label>
-                </div>
+
             </div>
         </div>
         

--- a/admin/tabs/extras-list-tab.php
+++ b/admin/tabs/extras-list-tab.php
@@ -37,12 +37,7 @@
                     </div>
                 <?php endif; ?>
                 
-                <!-- Status Badge -->
-                <div class="federwiegen-extra-status">
-                    <span class="federwiegen-status-badge <?php echo $extra->active ? 'available' : 'unavailable'; ?>">
-                        <?php echo $extra->active ? '✅ Aktiv' : '❌ Inaktiv'; ?>
-                    </span>
-                </div>
+
             </div>
             
             <div class="federwiegen-extra-content">

--- a/admin/tabs/extras-tab.php
+++ b/admin/tabs/extras-tab.php
@@ -8,7 +8,7 @@ if (isset($_POST['submit_extra'])) {
     $name = sanitize_text_field($_POST['name']);
     $price = floatval($_POST['price']);
     $image_url = esc_url_raw($_POST['image_url']);
-    $active = isset($_POST['active']) ? 1 : 0;
+    $active = 1;
     $sort_order = intval($_POST['sort_order']);
 
     if (isset($_POST['id']) && $_POST['id']) {
@@ -20,7 +20,6 @@ if (isset($_POST['submit_extra'])) {
                 'name' => $name,
                 'price' => $price,
                 'image_url' => $image_url,
-                'active' => $active,
                 'sort_order' => $sort_order
             ),
             array('id' => intval($_POST['id'])),
@@ -40,10 +39,9 @@ if (isset($_POST['submit_extra'])) {
                 'name' => $name,
                 'price' => $price,
                 'image_url' => $image_url,
-                'active' => $active,
                 'sort_order' => $sort_order
             ),
-            array('%d', '%s', '%f', '%s', '%d', '%d')
+            array('%d', '%s', '%f', '%s', '%d')
         );
         
         if ($result !== false) {
@@ -115,12 +113,7 @@ $extras = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE cat
                     <input type="number" name="sort_order" value="<?php echo $edit_item ? $edit_item->sort_order : '0'; ?>" min="0">
                 </div>
                 
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="active" value="1" <?php echo (!$edit_item || $edit_item->active) ? 'checked' : ''; ?>>
-                        Aktiv
-                    </label>
-                </div>
+
             </div>
             
             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">

--- a/admin/tabs/variants-add-tab.php
+++ b/admin/tabs/variants-add-tab.php
@@ -41,9 +41,10 @@
             <h4>📦 Verfügbarkeit</h4>
             <div class="federwiegen-form-row">
                 <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
+                    <label>Verfügbar</label>
+                    <label class="fw-toggle">
                         <input type="checkbox" name="available" value="1" checked>
-                        <span>Verfügbar</span>
+                        <span class="fw-slider"></span>
                     </label>
                 </div>
                 <div class="federwiegen-form-group">
@@ -78,12 +79,6 @@
                 <div class="federwiegen-form-group">
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" value="0" min="0">
-                </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" checked>
-                        <span>Aktiv</span>
-                    </label>
                 </div>
             </div>
         </div>

--- a/admin/tabs/variants-edit-tab.php
+++ b/admin/tabs/variants-edit-tab.php
@@ -42,9 +42,10 @@
             <h4>📦 Verfügbarkeit</h4>
             <div class="federwiegen-form-row">
                 <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
+                    <label>Verfügbar</label>
+                    <label class="fw-toggle">
                         <input type="checkbox" name="available" value="1" <?php echo ($edit_item->available ?? 1) ? 'checked' : ''; ?>>
-                        <span>Verfügbar</span>
+                        <span class="fw-slider"></span>
                     </label>
                 </div>
                 <div class="federwiegen-form-group">
@@ -85,12 +86,6 @@
                 <div class="federwiegen-form-group">
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
-                </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" <?php echo $edit_item->active ? 'checked' : ''; ?>>
-                        <span>Aktiv</span>
-                    </label>
                 </div>
             </div>
         </div>

--- a/admin/tabs/variants-tab.php
+++ b/admin/tabs/variants-tab.php
@@ -11,7 +11,6 @@ if (isset($_POST['submit_variant'])) {
     $price_from = isset($_POST['price_from']) ? floatval($_POST['price_from']) : 0;
     $available = isset($_POST['available']) ? 1 : 0;
     $availability_note = sanitize_text_field($_POST['availability_note']);
-    $active = isset($_POST['active']) ? 1 : 0;
     $sort_order = intval($_POST['sort_order']);
     
     // Handle multiple images
@@ -30,7 +29,6 @@ if (isset($_POST['submit_variant'])) {
             'price_from' => $price_from,
             'available' => $available,
             'availability_note' => $availability_note,
-            'active' => $active,
             'sort_order' => $sort_order
         ), $image_data);
         
@@ -55,7 +53,6 @@ if (isset($_POST['submit_variant'])) {
             'price_from' => $price_from,
             'available' => $available,
             'availability_note' => $availability_note,
-            'active' => $active,
             'sort_order' => $sort_order
         ), $image_data);
         
@@ -141,12 +138,6 @@ $variants = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE c
                     <input type="number" name="sort_order" value="<?php echo $edit_item ? $edit_item->sort_order : '0'; ?>" min="0">
                 </div>
                 
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="active" value="1" <?php echo (!$edit_item || $edit_item->active) ? 'checked' : ''; ?>>
-                        Aktiv
-                    </label>
-                </div>
             </div>
             
             <!-- Images Section -->

--- a/admin/variant-options-page.php
+++ b/admin/variant-options-page.php
@@ -23,6 +23,7 @@ if (isset($_POST['submit'])) {
     $variant_id = intval($_POST['variant_id']);
     $option_type = sanitize_text_field($_POST['option_type']);
     $option_id = intval($_POST['option_id']);
+    $available = isset($_POST['available']) ? 1 : 0;
 
     $table_name = $wpdb->prefix . 'federwiegen_variant_options';
 
@@ -33,10 +34,11 @@ if (isset($_POST['submit'])) {
             array(
                 'variant_id' => $variant_id,
                 'option_type' => $option_type,
-                'option_id' => $option_id
+                'option_id' => $option_id,
+                'available' => $available
             ),
             array('id' => intval($_POST['id'])),
-            array('%d', '%s', '%d'),
+            array('%d', '%s', '%d', '%d'),
             array('%d')
         );
         
@@ -52,9 +54,10 @@ if (isset($_POST['submit'])) {
             array(
                 'variant_id' => $variant_id,
                 'option_type' => $option_type,
-                'option_id' => $option_id
+                'option_id' => $option_id,
+                'available' => $available
             ),
-            array('%d', '%s', '%d')
+            array('%d', '%s', '%d', '%d')
         );
         
         if ($result !== false) {
@@ -229,6 +232,13 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                                         <option value="">Erst Option-Typ wählen...</option>
                                     </select>
                                 </div>
+                                <div class="federwiegen-form-group">
+                                    <label>Verfügbar</label>
+                                    <label class="fw-toggle">
+                                        <input type="checkbox" name="available" value="1" checked>
+                                        <span class="fw-slider"></span>
+                                    </label>
+                                </div>
                             </div>
                             
                             <div class="federwiegen-form-actions">
@@ -292,6 +302,13 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                                         <option value="">Erst Option-Typ wählen...</option>
                                     </select>
                                 </div>
+                                <div class="federwiegen-form-group">
+                                    <label>Verfügbar</label>
+                                    <label class="fw-toggle">
+                                        <input type="checkbox" name="available" value="1" <?php echo ($edit_item->available ?? 1) ? 'checked' : ''; ?>>
+                                        <span class="fw-slider"></span>
+                                    </label>
+                                </div>
                             </div>
                             
                             <div class="federwiegen-form-actions">
@@ -340,11 +357,11 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                             
                             <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 15px; margin-top: 15px;">
                                 <?php foreach ($options as $option): ?>
-                                <div style="background: white; border: 1px solid #ddd; border-radius: 6px; padding: 15px;">
+                                <div style="background: white; border: 1px solid #ddd; border-radius: 6px; padding: 15px; position: relative;">
                                     <div style="display: flex; justify-content: space-between; align-items: center;">
                                         <div>
                                             <strong>
-                                                <?php 
+                                                <?php
                                                 switch ($option->option_type) {
                                                     case 'condition':
                                                         echo '🔄 ' . esc_html($option->option_name);
@@ -367,6 +384,9 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                                             <a href="<?php echo admin_url('admin.php?page=federwiegen-variant-options&category=' . $selected_category . '&tab=list&delete=' . $option->id . '&fw_nonce=' . wp_create_nonce('federwiegen_admin_action')); ?>" class="button button-small" onclick="return confirm('Sind Sie sicher?')">🗑️</a>
                                         </div>
                                     </div>
+                                    <span class="federwiegen-status-badge <?php echo $option->available ? 'available' : 'unavailable'; ?>" style="position:absolute;top:10px;right:10px;">
+                                        <?php echo $option->available ? '✅ Verfügbar' : '❌ Nicht verfügbar'; ?>
+                                    </span>
                                 </div>
                                 <?php endforeach; ?>
                             </div>

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -597,7 +597,46 @@
         max-width: 100%;
     }
     
-    .federwiegen-nav-grid {
+.federwiegen-nav-grid {
         grid-template-columns: 1fr;
     }
+}
+
+/* Toggle Switch */
+.fw-toggle {
+    position: relative;
+    display: inline-block;
+    width: 46px;
+    height: 24px;
+}
+.fw-toggle input {
+    display: none;
+}
+.fw-slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    transition: .4s;
+    border-radius: 24px;
+}
+.fw-slider:before {
+    position: absolute;
+    content: "";
+    height: 20px;
+    width: 20px;
+    left: 2px;
+    bottom: 2px;
+    background-color: white;
+    transition: .4s;
+    border-radius: 50%;
+}
+.fw-toggle input:checked + .fw-slider {
+    background-color: #5f7f5f;
+}
+.fw-toggle input:checked + .fw-slider:before {
+    transform: translateX(22px);
 }

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -206,7 +206,7 @@ class Ajax {
         
         // Get variant-specific options
         $variant_options = $wpdb->get_results($wpdb->prepare(
-            "SELECT option_type, option_id FROM {$wpdb->prefix}federwiegen_variant_options WHERE variant_id = %d",
+            "SELECT option_type, option_id FROM {$wpdb->prefix}federwiegen_variant_options WHERE variant_id = %d AND available = 1",
             $variant_id
         ));
         

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -258,7 +258,7 @@ class Database {
         // Create variant options table if it doesn't exist
         $table_variant_options = $wpdb->prefix . 'federwiegen_variant_options';
         $variant_options_exists = $wpdb->get_var("SHOW TABLES LIKE '$table_variant_options'");
-        
+
         if (!$variant_options_exists) {
             $charset_collate = $wpdb->get_charset_collate();
             $sql = "CREATE TABLE $table_variant_options (
@@ -266,12 +266,18 @@ class Database {
                 variant_id mediumint(9) NOT NULL,
                 option_type varchar(50) NOT NULL,
                 option_id mediumint(9) NOT NULL,
+                available tinyint(1) DEFAULT 1,
                 PRIMARY KEY (id),
                 UNIQUE KEY variant_option (variant_id, option_type, option_id)
             ) $charset_collate;";
-            
+
             require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
             dbDelta($sql);
+        } else {
+            $column_exists = $wpdb->get_results("SHOW COLUMNS FROM $table_variant_options LIKE 'available'");
+            if (empty($column_exists)) {
+                $wpdb->query("ALTER TABLE $table_variant_options ADD COLUMN available TINYINT(1) DEFAULT 1 AFTER option_id");
+            }
         }
         
         // Create orders table if it doesn't exist
@@ -503,6 +509,7 @@ class Database {
             variant_id mediumint(9) NOT NULL,
             option_type varchar(50) NOT NULL,
             option_id mediumint(9) NOT NULL,
+            available tinyint(1) DEFAULT 1,
             PRIMARY KEY (id),
             UNIQUE KEY variant_option (variant_id, option_type, option_id)
         ) $charset_collate;";


### PR DESCRIPTION
## Summary
- drop unused `active` and global availability settings
- add per-variant option availability with toggle UI
- style new toggle switch in admin
- adapt AJAX calls for new availability logic

## Testing
- `php` was not available so PHP linting could not run

------
https://chatgpt.com/codex/tasks/task_b_6863b1f8df18833096fdc3af883b6a92