### PR TITLE
Fix availability display and admin forms

### DIFF
--- a/admin/colors-page.php
+++ b/admin/colors-page.php
@@ -202,12 +202,6 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                                     </label>
                                 </div>
                                 
-                                <div class="federwiegen-form-group">
-                                    <label>
-                                        <input type="checkbox" name="active" value="1" checked>
-                                        Aktiv
-                                    </label>
-                                </div>
                             </div>
                             
                             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">
@@ -265,12 +259,6 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                                     </label>
                                 </div>
                                 
-                                <div class="federwiegen-form-group">
-                                    <label>
-                                        <input type="checkbox" name="active" value="1" <?php checked($edit_item->active); ?>>
-                                        Aktiv
-                                    </label>
-                                </div>
                             </div>
                             
                             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">

--- a/admin/conditions-page.php
+++ b/admin/conditions-page.php
@@ -199,12 +199,6 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
                                     </label>
                                 </div>
                                 
-                                <div class="federwiegen-form-group">
-                                    <label>
-                                        <input type="checkbox" name="active" value="1" checked>
-                                        Aktiv
-                                    </label>
-                                </div>
                             </div>
                             
                             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">
@@ -260,12 +254,6 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
                                     </label>
                                 </div>
                                 
-                                <div class="federwiegen-form-group">
-                                    <label>
-                                        <input type="checkbox" name="active" value="1" <?php checked($edit_item->active); ?>>
-                                        Aktiv
-                                    </label>
-                                </div>
                             </div>
                             
                             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">

--- a/admin/tabs/colors-tab.php
+++ b/admin/tabs/colors-tab.php
@@ -268,6 +268,10 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
 
 .federwiegen-color-status {
     margin-bottom: 15px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
 }
 
 .federwiegen-color-actions {

--- a/admin/tabs/conditions-tab.php
+++ b/admin/tabs/conditions-tab.php
@@ -216,6 +216,7 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
     display: flex;
     gap: 15px;
     align-items: center;
+    flex-wrap: wrap;
 }
 
 .federwiegen-price-modifier {

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -463,6 +463,13 @@
     font-size: 12px;
 }
 
+.federwiegen-status,
+.federwiegen-status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
 .federwiegen-item-actions {
     padding: 15px;
     background: #f8f9fa;

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -221,7 +221,7 @@ class Ajax {
                 switch ($option->option_type) {
                     case 'condition':
                         $condition = $wpdb->get_row($wpdb->prepare(
-                            "SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE id = %d AND active = 1 AND available = 1",
+                            "SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE id = %d AND active = 1",
                             $option->option_id
                         ));
                         if ($condition) {
@@ -230,7 +230,7 @@ class Ajax {
                         break;
                     case 'product_color':
                         $color = $wpdb->get_row($wpdb->prepare(
-                            "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE id = %d AND active = 1 AND available = 1",
+                            "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE id = %d AND active = 1",
                             $option->option_id
                         ));
                         if ($color) {
@@ -239,7 +239,7 @@ class Ajax {
                         break;
                     case 'frame_color':
                         $color = $wpdb->get_row($wpdb->prepare(
-                            "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE id = %d AND active = 1 AND available = 1",
+                            "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE id = %d AND active = 1",
                             $option->option_id
                         ));
                         if ($color) {
@@ -266,17 +266,17 @@ class Ajax {
             
             if ($variant) {
                 $conditions = $wpdb->get_results($wpdb->prepare(
-                    "SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE category_id = %d AND active = 1 AND available = 1 ORDER BY sort_order",
+                    "SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE category_id = %d AND active = 1 ORDER BY sort_order",
                     $variant->category_id
                 ));
                 
                 $product_colors = $wpdb->get_results($wpdb->prepare(
-                    "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'product' AND active = 1 AND available = 1 ORDER BY sort_order",
+                    "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'product' AND active = 1 ORDER BY sort_order",
                     $variant->category_id
                 ));
                 
                 $frame_colors = $wpdb->get_results($wpdb->prepare(
-                    "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'frame' AND active = 1 AND available = 1 ORDER BY sort_order",
+                    "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'frame' AND active = 1 ORDER BY sort_order",
                     $variant->category_id
                 ));
 

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -54,17 +54,17 @@ $condition_tooltip = isset($category) ? ($category->condition_tooltip ?? '') : '
 
 // Get initial conditions and colors (will be updated via AJAX when variant is selected)
 $initial_conditions = $wpdb->get_results($wpdb->prepare(
-    "SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE category_id = %d AND active = 1 AND available = 1 ORDER BY sort_order",
+    "SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE category_id = %d AND active = 1 ORDER BY sort_order",
     $category_id
 ));
 
 $initial_product_colors = $wpdb->get_results($wpdb->prepare(
-    "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'product' AND active = 1 AND available = 1 ORDER BY sort_order",
+    "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'product' AND active = 1 ORDER BY sort_order",
     $category_id
 ));
 
 $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
-    "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'frame' AND active = 1 AND available = 1 ORDER BY sort_order",
+    "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'frame' AND active = 1 ORDER BY sort_order",
     $category_id
 ));
 ?>


### PR DESCRIPTION
## Summary
- show unavailable product options in frontend
- update AJAX queries for unavailable data
- remove outdated "Aktiv" checkbox in color & condition admin forms
- tweak admin styles for status badges

## Testing
- `php -l templates/product-page.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6863bcaaba108330b325a31df1a91eb9