### PR TITLE
Remove inactive settings

### DIFF
--- a/admin/tabs/categories-add-tab.php
+++ b/admin/tabs/categories-add-tab.php
@@ -153,12 +153,6 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" min="0">
                 </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" checked>
-                        <span>Aktiv</span>
-                    </label>
-                </div>
             </div>
         </div>
         

--- a/admin/tabs/categories-edit-tab.php
+++ b/admin/tabs/categories-edit-tab.php
@@ -171,12 +171,6 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
                 </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" <?php echo $edit_item->active ? 'checked' : ''; ?>>
-                        <span>Aktiv</span>
-                    </label>
-                </div>
             </div>
         </div>
         

--- a/admin/tabs/categories-list-tab.php
+++ b/admin/tabs/categories-list-tab.php
@@ -34,12 +34,6 @@
                     </div>
                 <?php endif; ?>
                 
-                <!-- Status Badge -->
-                <div class="federwiegen-category-status">
-                    <span class="federwiegen-status-badge <?php echo $category->active ? 'available' : 'unavailable'; ?>">
-                        <?php echo $category->active ? '✅ Aktiv' : '❌ Inaktiv'; ?>
-                    </span>
-                </div>
             </div>
             
             <div class="federwiegen-category-content">

--- a/admin/tabs/colors-tab.php
+++ b/admin/tabs/colors-tab.php
@@ -113,19 +113,7 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                     <input type="number" name="sort_order" value="<?php echo $edit_item ? $edit_item->sort_order : '0'; ?>" min="0">
                 </div>
                 
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="available" value="1" <?php echo (!$edit_item || $edit_item->available) ? 'checked' : ''; ?>>
-                        Verfügbar
-                    </label>
-                </div>
                 
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="active" value="1" <?php echo (!$edit_item || $edit_item->active) ? 'checked' : ''; ?>>
-                        Aktiv
-                    </label>
-                </div>
             </div>
             
             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">
@@ -158,11 +146,7 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                     <div class="federwiegen-color-info">
                         <h5><?php echo esc_html($color->name); ?></h5>
                         <code><?php echo esc_html($color->color_code); ?></code>
-                        <div class="federwiegen-color-status">
-                            <span class="federwiegen-status <?php echo $color->available ? 'available' : 'unavailable'; ?>">
-                                <?php echo $color->available ? '✅ Verfügbar' : '❌ Nicht verfügbar'; ?>
-                            </span>
-                        </div>
+                        
                     </div>
                     <div class="federwiegen-color-actions">
                         <a href="<?php echo admin_url('admin.php?page=federwiegen-products&category=' . $selected_category . '&tab=colors&edit_color=' . $color->id); ?>" class="button button-small">Bearbeiten</a>
@@ -192,11 +176,7 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                     <div class="federwiegen-color-info">
                         <h5><?php echo esc_html($color->name); ?></h5>
                         <code><?php echo esc_html($color->color_code); ?></code>
-                        <div class="federwiegen-color-status">
-                            <span class="federwiegen-status <?php echo $color->available ? 'available' : 'unavailable'; ?>">
-                                <?php echo $color->available ? '✅ Verfügbar' : '❌ Nicht verfügbar'; ?>
-                            </span>
-                        </div>
+                        
                     </div>
                     <div class="federwiegen-color-actions">
                         <a href="<?php echo admin_url('admin.php?page=federwiegen-products&category=' . $selected_category . '&tab=colors&edit_color=' . $color->id); ?>" class="button button-small">Bearbeiten</a>

--- a/admin/tabs/conditions-tab.php
+++ b/admin/tabs/conditions-tab.php
@@ -110,19 +110,7 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
                     <input type="number" name="sort_order" value="<?php echo $edit_item ? $edit_item->sort_order : '0'; ?>" min="0">
                 </div>
                 
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="available" value="1" <?php echo (!$edit_item || $edit_item->available) ? 'checked' : ''; ?>>
-                        Verfügbar
-                    </label>
-                </div>
                 
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="active" value="1" <?php echo (!$edit_item || $edit_item->active) ? 'checked' : ''; ?>>
-                        Aktiv
-                    </label>
-                </div>
             </div>
             
             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">
@@ -165,9 +153,6 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
                                 echo '<span style="color: #666;">±0%</span>';
                             }
                             ?>
-                        </span>
-                        <span class="federwiegen-status <?php echo $condition->available ? 'available' : 'unavailable'; ?>">
-                            <?php echo $condition->available ? '✅ Verfügbar' : '❌ Nicht verfügbar'; ?>
                         </span>
                     </div>
                 </div>

--- a/admin/tabs/durations-add-tab.php
+++ b/admin/tabs/durations-add-tab.php
@@ -42,12 +42,6 @@
         <!-- Einstellungen -->
         <div class="federwiegen-form-section">
             <h4>⚙️ Einstellungen</h4>
-            <div class="federwiegen-form-group">
-                <label class="federwiegen-checkbox-label">
-                    <input type="checkbox" name="active" value="1" checked>
-                    <span>Aktiv</span>
-                </label>
-            </div>
         </div>
         
         <!-- Actions -->

--- a/admin/tabs/durations-edit-tab.php
+++ b/admin/tabs/durations-edit-tab.php
@@ -43,12 +43,7 @@
         <!-- Einstellungen -->
         <div class="federwiegen-form-section">
             <h4>⚙️ Einstellungen</h4>
-            <div class="federwiegen-form-group">
-                <label class="federwiegen-checkbox-label">
-                    <input type="checkbox" name="active" value="1" <?php echo $edit_item->active ? 'checked' : ''; ?>>
-                    <span>Aktiv</span>
-                </label>
-            </div>
+            
         </div>
         
         <!-- Actions -->

--- a/admin/tabs/durations-list-tab.php
+++ b/admin/tabs/durations-list-tab.php
@@ -52,11 +52,6 @@
                         <small>Sortierung: <?php echo $duration->sort_order; ?></small>
                     </div>
                     
-                    <div class="federwiegen-duration-status">
-                        <span class="federwiegen-status-badge <?php echo $duration->active ? 'available' : 'unavailable'; ?>">
-                            <?php echo $duration->active ? '✅ Aktiv' : '❌ Inaktiv'; ?>
-                        </span>
-                    </div>
                 </div>
                 
                 <div class="federwiegen-duration-actions">

--- a/admin/tabs/durations-tab.php
+++ b/admin/tabs/durations-tab.php
@@ -113,12 +113,6 @@ $durations = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE 
                     <input type="number" name="sort_order" value="<?php echo $edit_item ? $edit_item->sort_order : '0'; ?>" min="0">
                 </div>
                 
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="active" value="1" <?php echo (!$edit_item || $edit_item->active) ? 'checked' : ''; ?>>
-                        Aktiv
-                    </label>
-                </div>
             </div>
             
             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">

--- a/admin/tabs/extras-add-tab.php
+++ b/admin/tabs/extras-add-tab.php
@@ -48,12 +48,6 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" value="0" min="0">
                 </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" checked>
-                        <span>Aktiv</span>
-                    </label>
-                </div>
             </div>
         </div>
         

--- a/admin/tabs/extras-edit-tab.php
+++ b/admin/tabs/extras-edit-tab.php
@@ -55,12 +55,6 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
                 </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" <?php echo $edit_item->active ? 'checked' : ''; ?>>
-                        <span>Aktiv</span>
-                    </label>
-                </div>
             </div>
         </div>
         

--- a/admin/tabs/extras-list-tab.php
+++ b/admin/tabs/extras-list-tab.php
@@ -37,12 +37,6 @@
                     </div>
                 <?php endif; ?>
                 
-                <!-- Status Badge -->
-                <div class="federwiegen-extra-status">
-                    <span class="federwiegen-status-badge <?php echo $extra->active ? 'available' : 'unavailable'; ?>">
-                        <?php echo $extra->active ? '✅ Aktiv' : '❌ Inaktiv'; ?>
-                    </span>
-                </div>
             </div>
             
             <div class="federwiegen-extra-content">

--- a/admin/tabs/extras-tab.php
+++ b/admin/tabs/extras-tab.php
@@ -115,12 +115,6 @@ $extras = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE cat
                     <input type="number" name="sort_order" value="<?php echo $edit_item ? $edit_item->sort_order : '0'; ?>" min="0">
                 </div>
                 
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="active" value="1" <?php echo (!$edit_item || $edit_item->active) ? 'checked' : ''; ?>>
-                        Aktiv
-                    </label>
-                </div>
             </div>
             
             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">
@@ -163,9 +157,6 @@ $extras = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE cat
                     <h5><?php echo esc_html($extra->name); ?></h5>
                     <div class="federwiegen-item-meta">
                         <span class="federwiegen-price"><?php echo number_format($extra->price, 2, ',', '.'); ?>€</span>
-                        <span class="federwiegen-status <?php echo $extra->active ? 'available' : 'unavailable'; ?>">
-                            <?php echo $extra->active ? '✅ Aktiv' : '❌ Inaktiv'; ?>
-                        </span>
                     </div>
                 </div>
                 

--- a/admin/tabs/variants-add-tab.php
+++ b/admin/tabs/variants-add-tab.php
@@ -41,9 +41,10 @@
             <h4>📦 Verfügbarkeit</h4>
             <div class="federwiegen-form-row">
                 <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
+                    <label>Verfügbar</label>
+                    <label class="federwiegen-toggle">
                         <input type="checkbox" name="available" value="1" checked>
-                        <span>Verfügbar</span>
+                        <span class="federwiegen-toggle-slider"></span>
                     </label>
                 </div>
                 <div class="federwiegen-form-group">

--- a/admin/tabs/variants-edit-tab.php
+++ b/admin/tabs/variants-edit-tab.php
@@ -42,9 +42,10 @@
             <h4>📦 Verfügbarkeit</h4>
             <div class="federwiegen-form-row">
                 <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
+                    <label>Verfügbar</label>
+                    <label class="federwiegen-toggle">
                         <input type="checkbox" name="available" value="1" <?php echo ($edit_item->available ?? 1) ? 'checked' : ''; ?>>
-                        <span>Verfügbar</span>
+                        <span class="federwiegen-toggle-slider"></span>
                     </label>
                 </div>
                 <div class="federwiegen-form-group">

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -608,3 +608,27 @@
         grid-template-columns: 1fr;
     }
 }
+
+/* Toggle Switch */
+.federwiegen-toggle {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+}
+.federwiegen-toggle input { opacity: 0; width: 0; height: 0; }
+.federwiegen-toggle-slider {
+  position: absolute; cursor: pointer; top: 0; left: 0; right: 0; bottom: 0;
+  background-color: #ccc; transition: .2s; border-radius: 34px;
+}
+.federwiegen-toggle-slider:before {
+  position: absolute; content: ""; height: 16px; width: 16px;
+  left: 2px; bottom: 2px; background-color: white; transition: .2s; border-radius: 50%;
+}
+.federwiegen-toggle input:checked + .federwiegen-toggle-slider {
+  background-color: #5f7f5f;
+}
+.federwiegen-toggle input:checked + .federwiegen-toggle-slider:before {
+  transform: translateX(20px);
+}
+


### PR DESCRIPTION
## Summary
- drop unused Active/Available flags from most admin forms and lists
- switch variant availability checkbox to a toggle
- add toggle switch styles

## Testing
- `php -l admin/tabs/*.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6863c352cd6c8330a9a902f9aa498884