### PR TITLE
Remove status badges from attribute overviews

### DIFF
--- a/admin/colors-page.php
+++ b/admin/colors-page.php
@@ -305,9 +305,6 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                                         </div>
                                     </div>
                                     <div class="federwiegen-item-meta">
-                                        <span class="federwiegen-status <?php echo $color->available ? 'available' : 'unavailable'; ?>">
-                                            <?php echo $color->available ? '✅ Verfügbar' : '❌ Nicht verfügbar'; ?>
-                                        </span>
                                     </div>
                                 </div>
                                 
@@ -343,11 +340,7 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                                             <code style="font-size: 12px;"><?php echo esc_html($color->color_code); ?></code>
                                         </div>
                                     </div>
-                                    <div class="federwiegen-item-meta">
-                                        <span class="federwiegen-status <?php echo $color->available ? 'available' : 'unavailable'; ?>">
-                                            <?php echo $color->available ? '✅ Verfügbar' : '❌ Nicht verfügbar'; ?>
-                                        </span>
-                                    </div>
+                                    <div class="federwiegen-item-meta"></div>
                                 </div>
                                 
                                 <div class="federwiegen-item-actions">

--- a/admin/conditions-page.php
+++ b/admin/conditions-page.php
@@ -307,9 +307,6 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
                                             }
                                             ?>
                                         </span>
-                                        <span class="federwiegen-status <?php echo $condition->available ? 'available' : 'unavailable'; ?>">
-                                            <?php echo $condition->available ? '✅ Verfügbar' : '❌ Nicht verfügbar'; ?>
-                                        </span>
                                     </div>
                                 </div>
                                 

--- a/admin/tabs/categories-list-tab.php
+++ b/admin/tabs/categories-list-tab.php
@@ -34,12 +34,6 @@
                     </div>
                 <?php endif; ?>
                 
-                <!-- Status Badge -->
-                <div class="federwiegen-category-status">
-                    <span class="federwiegen-status-badge <?php echo $category->active ? 'available' : 'unavailable'; ?>">
-                        <?php echo $category->active ? '✅ Aktiv' : '❌ Inaktiv'; ?>
-                    </span>
-                </div>
             </div>
             
             <div class="federwiegen-category-content">

--- a/admin/tabs/colors-tab.php
+++ b/admin/tabs/colors-tab.php
@@ -158,11 +158,7 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                     <div class="federwiegen-color-info">
                         <h5><?php echo esc_html($color->name); ?></h5>
                         <code><?php echo esc_html($color->color_code); ?></code>
-                        <div class="federwiegen-color-status">
-                            <span class="federwiegen-status <?php echo $color->available ? 'available' : 'unavailable'; ?>">
-                                <?php echo $color->available ? '✅ Verfügbar' : '❌ Nicht verfügbar'; ?>
-                            </span>
-                        </div>
+                        
                     </div>
                     <div class="federwiegen-color-actions">
                         <a href="<?php echo admin_url('admin.php?page=federwiegen-products&category=' . $selected_category . '&tab=colors&edit_color=' . $color->id); ?>" class="button button-small">Bearbeiten</a>
@@ -192,11 +188,6 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                     <div class="federwiegen-color-info">
                         <h5><?php echo esc_html($color->name); ?></h5>
                         <code><?php echo esc_html($color->color_code); ?></code>
-                        <div class="federwiegen-color-status">
-                            <span class="federwiegen-status <?php echo $color->available ? 'available' : 'unavailable'; ?>">
-                                <?php echo $color->available ? '✅ Verfügbar' : '❌ Nicht verfügbar'; ?>
-                            </span>
-                        </div>
                     </div>
                     <div class="federwiegen-color-actions">
                         <a href="<?php echo admin_url('admin.php?page=federwiegen-products&category=' . $selected_category . '&tab=colors&edit_color=' . $color->id); ?>" class="button button-small">Bearbeiten</a>

--- a/admin/tabs/conditions-tab.php
+++ b/admin/tabs/conditions-tab.php
@@ -166,9 +166,6 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
                             }
                             ?>
                         </span>
-                        <span class="federwiegen-status <?php echo $condition->available ? 'available' : 'unavailable'; ?>">
-                            <?php echo $condition->available ? '✅ Verfügbar' : '❌ Nicht verfügbar'; ?>
-                        </span>
                     </div>
                 </div>
                 

--- a/admin/tabs/durations-list-tab.php
+++ b/admin/tabs/durations-list-tab.php
@@ -52,11 +52,6 @@
                         <small>Sortierung: <?php echo $duration->sort_order; ?></small>
                     </div>
                     
-                    <div class="federwiegen-duration-status">
-                        <span class="federwiegen-status-badge <?php echo $duration->active ? 'available' : 'unavailable'; ?>">
-                            <?php echo $duration->active ? '✅ Aktiv' : '❌ Inaktiv'; ?>
-                        </span>
-                    </div>
                 </div>
                 
                 <div class="federwiegen-duration-actions">

--- a/admin/tabs/durations-tab.php
+++ b/admin/tabs/durations-tab.php
@@ -153,9 +153,6 @@ $durations = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE 
                         <?php if ($duration->discount > 0): ?>
                             <span class="federwiegen-discount-badge">-<?php echo round($duration->discount * 100); ?>% Rabatt</span>
                         <?php endif; ?>
-                        <span class="federwiegen-status <?php echo $duration->active ? 'available' : 'unavailable'; ?>">
-                            <?php echo $duration->active ? '✅ Aktiv' : '❌ Inaktiv'; ?>
-                        </span>
                     </div>
                 </div>
                 

--- a/admin/tabs/extras-list-tab.php
+++ b/admin/tabs/extras-list-tab.php
@@ -37,12 +37,6 @@
                     </div>
                 <?php endif; ?>
                 
-                <!-- Status Badge -->
-                <div class="federwiegen-extra-status">
-                    <span class="federwiegen-status-badge <?php echo $extra->active ? 'available' : 'unavailable'; ?>">
-                        <?php echo $extra->active ? '✅ Aktiv' : '❌ Inaktiv'; ?>
-                    </span>
-                </div>
             </div>
             
             <div class="federwiegen-extra-content">

--- a/admin/tabs/extras-tab.php
+++ b/admin/tabs/extras-tab.php
@@ -163,9 +163,6 @@ $extras = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE cat
                     <h5><?php echo esc_html($extra->name); ?></h5>
                     <div class="federwiegen-item-meta">
                         <span class="federwiegen-price"><?php echo number_format($extra->price, 2, ',', '.'); ?>€</span>
-                        <span class="federwiegen-status <?php echo $extra->active ? 'available' : 'unavailable'; ?>">
-                            <?php echo $extra->active ? '✅ Aktiv' : '❌ Inaktiv'; ?>
-                        </span>
                     </div>
                 </div>
                 


### PR DESCRIPTION
## Summary
- hide status badges from category, extra, duration, condition and color overviews
- keep badges for variants untouched

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863c83085608330980357051057c525