### PR TITLE
Remove active/available toggles

### DIFF
--- a/admin/analytics-page.php
+++ b/admin/analytics-page.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
 global $wpdb;
 
 // Get all categories for dropdown
-$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE active = 1 ORDER BY sort_order, name");
+$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories ORDER BY sort_order, name");
 
 // Get selected category from URL parameter
 $selected_category = isset($_GET['category']) ? intval($_GET['category']) : (isset($categories[0]) ? $categories[0]->id : 0);

--- a/admin/colors-page.php
+++ b/admin/colors-page.php
@@ -7,7 +7,7 @@ global $wpdb;
 $table_name = $wpdb->prefix . 'federwiegen_colors';
 
 // Get all categories for dropdown
-$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE active = 1 ORDER BY sort_order, name");
+$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories ORDER BY sort_order, name");
 
 // Get selected category from URL parameter
 $selected_category = isset($_GET['category']) ? intval($_GET['category']) : (isset($categories[0]) ? $categories[0]->id : 1);

--- a/admin/conditions-page.php
+++ b/admin/conditions-page.php
@@ -7,7 +7,7 @@ global $wpdb;
 $table_name = $wpdb->prefix . 'federwiegen_conditions';
 
 // Get all categories for dropdown
-$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE active = 1 ORDER BY sort_order, name");
+$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories ORDER BY sort_order, name");
 
 // Get selected category from URL parameter
 $selected_category = isset($_GET['category']) ? intval($_GET['category']) : (isset($categories[0]) ? $categories[0]->id : 1);
@@ -23,7 +23,6 @@ if (isset($_POST['submit'])) {
     $description = sanitize_textarea_field($_POST['description']);
     $price_modifier = floatval($_POST['price_modifier']) / 100; // Convert percentage to decimal
     $available = isset($_POST['available']) ? 1 : 0;
-    $active = isset($_POST['active']) ? 1 : 0;
     $sort_order = intval($_POST['sort_order']);
 
     if (isset($_POST['id']) && $_POST['id']) {
@@ -36,11 +35,10 @@ if (isset($_POST['submit'])) {
                 'description' => $description,
                 'price_modifier' => $price_modifier,
                 'available' => $available,
-                'active' => $active,
                 'sort_order' => $sort_order
             ),
             array('id' => intval($_POST['id'])),
-            array('%d', '%s', '%s', '%f', '%d', '%d', '%d'),
+            array('%d', '%s', '%s', '%f', '%d', '%d'),
             array('%d')
         );
         
@@ -59,10 +57,9 @@ if (isset($_POST['submit'])) {
                 'description' => $description,
                 'price_modifier' => $price_modifier,
                 'available' => $available,
-                'active' => $active,
                 'sort_order' => $sort_order
             ),
-            array('%d', '%s', '%s', '%f', '%d', '%d', '%d')
+            array('%d', '%s', '%s', '%f', '%d', '%d')
         );
         
         if ($result !== false) {

--- a/admin/durations-page.php
+++ b/admin/durations-page.php
@@ -7,7 +7,7 @@ global $wpdb;
 $table_name = $wpdb->prefix . 'federwiegen_durations';
 
 // Get all categories for dropdown
-$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE active = 1 ORDER BY sort_order, name");
+$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories ORDER BY sort_order, name");
 
 // Get selected category from URL parameter
 $selected_category = isset($_GET['category']) ? intval($_GET['category']) : (isset($categories[0]) ? $categories[0]->id : 1);

--- a/admin/extras-page.php
+++ b/admin/extras-page.php
@@ -7,7 +7,7 @@ global $wpdb;
 $table_name = $wpdb->prefix . 'federwiegen_extras';
 
 // Get all categories for dropdown
-$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE active = 1 ORDER BY sort_order, name");
+$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories ORDER BY sort_order, name");
 
 // Get selected category from URL parameter
 $selected_category = isset($_GET['category']) ? intval($_GET['category']) : (isset($categories[0]) ? $categories[0]->id : 1);

--- a/admin/links-page.php
+++ b/admin/links-page.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
 global $wpdb;
 
 // Get all categories for dropdown
-$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE active = 1 ORDER BY sort_order, name");
+$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories ORDER BY sort_order, name");
 
 // Get selected category from URL parameter
 $selected_category = isset($_GET['category']) ? intval($_GET['category']) : (isset($categories[0]) ? $categories[0]->id : 1);
@@ -113,12 +113,12 @@ if (isset($_GET['edit'])) {
 $current_category = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE id = %d", $selected_category));
 
 // Get all data for dropdowns (filtered by category)
-$variants = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_variants WHERE category_id = %d AND active = 1 ORDER BY sort_order, name", $selected_category));
-$extras = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_extras WHERE category_id = %d AND active = 1 ORDER BY sort_order, name", $selected_category));
-$durations = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_durations WHERE category_id = %d AND active = 1 ORDER BY sort_order, months_minimum", $selected_category));
-$conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE category_id = %d AND active = 1 ORDER BY sort_order, name", $selected_category));
-$product_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'product' AND active = 1 ORDER BY sort_order, name", $selected_category));
-$frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'frame' AND active = 1 ORDER BY sort_order, name", $selected_category));
+$variants = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_variants WHERE category_id = %d ORDER BY sort_order, name", $selected_category));
+$extras = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_extras WHERE category_id = %d ORDER BY sort_order, name", $selected_category));
+$durations = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_durations WHERE category_id = %d ORDER BY sort_order, months_minimum", $selected_category));
+$conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE category_id = %d ORDER BY sort_order, name", $selected_category));
+$product_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'product' ORDER BY sort_order, name", $selected_category));
+$frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'frame' ORDER BY sort_order, name", $selected_category));
 
 // Get all links with names (filtered by category)
 $links = $wpdb->get_results($wpdb->prepare("

--- a/admin/main-page.php
+++ b/admin/main-page.php
@@ -6,14 +6,14 @@ if (!defined('ABSPATH')) {
 global $wpdb;
 
 // Get categories count
-$categories_count = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}federwiegen_categories WHERE active = 1");
-$variants_count = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}federwiegen_variants WHERE active = 1");
-$extras_count = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}federwiegen_extras WHERE active = 1");
-$durations_count = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}federwiegen_durations WHERE active = 1");
+$categories_count = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}federwiegen_categories");
+$variants_count = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}federwiegen_variants");
+$extras_count = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}federwiegen_extras");
+$durations_count = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}federwiegen_durations");
 $links_count = $wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}federwiegen_links");
 
 // Get recent categories
-$recent_categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE active = 1 ORDER BY id DESC LIMIT 3");
+$recent_categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories ORDER BY id DESC LIMIT 3");
 
 // Get branding settings
 $branding = array();

--- a/admin/pricing-page.php
+++ b/admin/pricing-page.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
 global $wpdb;
 
 // Get all categories for dropdown
-$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE active = 1 ORDER BY sort_order, name");
+$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories ORDER BY sort_order, name");
 
 // Get selected category from URL parameter
 $selected_category = isset($_GET['category']) ? intval($_GET['category']) : (isset($categories[0]) ? $categories[0]->id : 1);

--- a/admin/products-page.php
+++ b/admin/products-page.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
 global $wpdb;
 
 // Get all categories for dropdown
-$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE active = 1 ORDER BY sort_order, name");
+$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories ORDER BY sort_order, name");
 
 // Get selected category from URL parameter
 $selected_category = isset($_GET['category']) ? intval($_GET['category']) : (isset($categories[0]) ? $categories[0]->id : 1);

--- a/admin/tabs/categories-add-tab.php
+++ b/admin/tabs/categories-add-tab.php
@@ -153,12 +153,6 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" min="0">
                 </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" checked>
-                        <span>Aktiv</span>
-                    </label>
-                </div>
             </div>
         </div>
         

--- a/admin/tabs/categories-edit-tab.php
+++ b/admin/tabs/categories-edit-tab.php
@@ -171,12 +171,6 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
                 </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" <?php echo $edit_item->active ? 'checked' : ''; ?>>
-                        <span>Aktiv</span>
-                    </label>
-                </div>
             </div>
         </div>
         

--- a/admin/tabs/colors-tab.php
+++ b/admin/tabs/colors-tab.php
@@ -8,8 +8,7 @@ if (isset($_POST['submit_color'])) {
     $name = sanitize_text_field($_POST['name']);
     $color_code = sanitize_hex_color($_POST['color_code']);
     $color_type = sanitize_text_field($_POST['color_type']);
-    $available = isset($_POST['available']) ? 1 : 0;
-    $active = isset($_POST['active']) ? 1 : 0;
+    $available = 1;
     $sort_order = intval($_POST['sort_order']);
 
     if (isset($_POST['id']) && $_POST['id']) {
@@ -22,11 +21,10 @@ if (isset($_POST['submit_color'])) {
                 'color_code' => $color_code,
                 'color_type' => $color_type,
                 'available' => $available,
-                'active' => $active,
                 'sort_order' => $sort_order
             ),
             array('id' => intval($_POST['id'])),
-            array('%d', '%s', '%s', '%s', '%d', '%d', '%d'),
+            array('%d', '%s', '%s', '%s', '%d'),
             array('%d')
         );
         
@@ -43,10 +41,9 @@ if (isset($_POST['submit_color'])) {
                 'color_code' => $color_code,
                 'color_type' => $color_type,
                 'available' => $available,
-                'active' => $active,
                 'sort_order' => $sort_order
             ),
-            array('%d', '%s', '%s', '%s', '%d', '%d', '%d')
+            array('%d', '%s', '%s', '%s', '%d')
         );
         
         if ($result !== false) {
@@ -113,19 +110,6 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                     <input type="number" name="sort_order" value="<?php echo $edit_item ? $edit_item->sort_order : '0'; ?>" min="0">
                 </div>
                 
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="available" value="1" <?php echo (!$edit_item || $edit_item->available) ? 'checked' : ''; ?>>
-                        Verfügbar
-                    </label>
-                </div>
-                
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="active" value="1" <?php echo (!$edit_item || $edit_item->active) ? 'checked' : ''; ?>>
-                        Aktiv
-                    </label>
-                </div>
             </div>
             
             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">

--- a/admin/tabs/conditions-tab.php
+++ b/admin/tabs/conditions-tab.php
@@ -8,8 +8,7 @@ if (isset($_POST['submit_condition'])) {
     $name = sanitize_text_field($_POST['name']);
     $description = sanitize_textarea_field($_POST['description']);
     $price_modifier = floatval($_POST['price_modifier']) / 100; // Convert percentage to decimal
-    $available = isset($_POST['available']) ? 1 : 0;
-    $active = isset($_POST['active']) ? 1 : 0;
+    $available = 1;
     $sort_order = intval($_POST['sort_order']);
 
     if (isset($_POST['id']) && $_POST['id']) {
@@ -21,12 +20,10 @@ if (isset($_POST['submit_condition'])) {
                 'name' => $name,
                 'description' => $description,
                 'price_modifier' => $price_modifier,
-                'available' => $available,
-                'active' => $active,
                 'sort_order' => $sort_order
             ),
             array('id' => intval($_POST['id'])),
-            array('%d', '%s', '%s', '%f', '%d', '%d', '%d'),
+            array('%d', '%s', '%s', '%f', '%d'),
             array('%d')
         );
         
@@ -42,11 +39,9 @@ if (isset($_POST['submit_condition'])) {
                 'name' => $name,
                 'description' => $description,
                 'price_modifier' => $price_modifier,
-                'available' => $available,
-                'active' => $active,
                 'sort_order' => $sort_order
             ),
-            array('%d', '%s', '%s', '%f', '%d', '%d', '%d')
+            array('%d', '%s', '%s', '%f', '%d')
         );
         
         if ($result !== false) {
@@ -110,19 +105,6 @@ $conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE
                     <input type="number" name="sort_order" value="<?php echo $edit_item ? $edit_item->sort_order : '0'; ?>" min="0">
                 </div>
                 
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="available" value="1" <?php echo (!$edit_item || $edit_item->available) ? 'checked' : ''; ?>>
-                        Verfügbar
-                    </label>
-                </div>
-                
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="active" value="1" <?php echo (!$edit_item || $edit_item->active) ? 'checked' : ''; ?>>
-                        Aktiv
-                    </label>
-                </div>
             </div>
             
             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">

--- a/admin/tabs/durations-add-tab.php
+++ b/admin/tabs/durations-add-tab.php
@@ -42,12 +42,6 @@
         <!-- Einstellungen -->
         <div class="federwiegen-form-section">
             <h4>⚙️ Einstellungen</h4>
-            <div class="federwiegen-form-group">
-                <label class="federwiegen-checkbox-label">
-                    <input type="checkbox" name="active" value="1" checked>
-                    <span>Aktiv</span>
-                </label>
-            </div>
         </div>
         
         <!-- Actions -->

--- a/admin/tabs/durations-edit-tab.php
+++ b/admin/tabs/durations-edit-tab.php
@@ -41,15 +41,6 @@
         </div>
         
         <!-- Einstellungen -->
-        <div class="federwiegen-form-section">
-            <h4>⚙️ Einstellungen</h4>
-            <div class="federwiegen-form-group">
-                <label class="federwiegen-checkbox-label">
-                    <input type="checkbox" name="active" value="1" <?php echo $edit_item->active ? 'checked' : ''; ?>>
-                    <span>Aktiv</span>
-                </label>
-            </div>
-        </div>
         
         <!-- Actions -->
         <div class="federwiegen-form-actions">

--- a/admin/tabs/durations-tab.php
+++ b/admin/tabs/durations-tab.php
@@ -14,7 +14,6 @@ if (isset($_POST['submit_duration'])) {
     $name = sanitize_text_field($_POST['name']);
     $months_minimum = intval($_POST['months_minimum']);
     $discount = floatval($_POST['discount']) / 100; // Convert percentage to decimal
-    $active = isset($_POST['active']) ? 1 : 0;
     $sort_order = intval($_POST['sort_order']);
 
     if (isset($_POST['id']) && $_POST['id']) {
@@ -26,11 +25,10 @@ if (isset($_POST['submit_duration'])) {
                 'name' => $name,
                 'months_minimum' => $months_minimum,
                 'discount' => $discount,
-                'active' => $active,
                 'sort_order' => $sort_order
             ),
             array('id' => intval($_POST['id'])),
-            array('%d', '%s', '%d', '%f', '%d', '%d'),
+            array('%d', '%s', '%d', '%f', '%d'),
             array('%d')
         );
         
@@ -46,10 +44,9 @@ if (isset($_POST['submit_duration'])) {
                 'name' => $name,
                 'months_minimum' => $months_minimum,
                 'discount' => $discount,
-                'active' => $active,
                 'sort_order' => $sort_order
             ),
-            array('%d', '%s', '%d', '%f', '%d', '%d')
+            array('%d', '%s', '%d', '%f', '%d')
         );
         
         if ($result !== false) {
@@ -113,12 +110,6 @@ $durations = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE 
                     <input type="number" name="sort_order" value="<?php echo $edit_item ? $edit_item->sort_order : '0'; ?>" min="0">
                 </div>
                 
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="active" value="1" <?php echo (!$edit_item || $edit_item->active) ? 'checked' : ''; ?>>
-                        Aktiv
-                    </label>
-                </div>
             </div>
             
             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">

--- a/admin/tabs/extras-add-tab.php
+++ b/admin/tabs/extras-add-tab.php
@@ -48,12 +48,6 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" value="0" min="0">
                 </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" checked>
-                        <span>Aktiv</span>
-                    </label>
-                </div>
             </div>
         </div>
         

--- a/admin/tabs/extras-edit-tab.php
+++ b/admin/tabs/extras-edit-tab.php
@@ -55,12 +55,6 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
                 </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" <?php echo $edit_item->active ? 'checked' : ''; ?>>
-                        <span>Aktiv</span>
-                    </label>
-                </div>
             </div>
         </div>
         

--- a/admin/tabs/extras-tab.php
+++ b/admin/tabs/extras-tab.php
@@ -8,7 +8,6 @@ if (isset($_POST['submit_extra'])) {
     $name = sanitize_text_field($_POST['name']);
     $price = floatval($_POST['price']);
     $image_url = esc_url_raw($_POST['image_url']);
-    $active = isset($_POST['active']) ? 1 : 0;
     $sort_order = intval($_POST['sort_order']);
 
     if (isset($_POST['id']) && $_POST['id']) {
@@ -20,11 +19,10 @@ if (isset($_POST['submit_extra'])) {
                 'name' => $name,
                 'price' => $price,
                 'image_url' => $image_url,
-                'active' => $active,
                 'sort_order' => $sort_order
             ),
             array('id' => intval($_POST['id'])),
-            array('%d', '%s', '%f', '%s', '%d', '%d'),
+            array('%d', '%s', '%f', '%s', '%d'),
             array('%d')
         );
         
@@ -40,10 +38,9 @@ if (isset($_POST['submit_extra'])) {
                 'name' => $name,
                 'price' => $price,
                 'image_url' => $image_url,
-                'active' => $active,
                 'sort_order' => $sort_order
             ),
-            array('%d', '%s', '%f', '%s', '%d', '%d')
+            array('%d', '%s', '%f', '%s', '%d')
         );
         
         if ($result !== false) {
@@ -115,12 +112,6 @@ $extras = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE cat
                     <input type="number" name="sort_order" value="<?php echo $edit_item ? $edit_item->sort_order : '0'; ?>" min="0">
                 </div>
                 
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="active" value="1" <?php echo (!$edit_item || $edit_item->active) ? 'checked' : ''; ?>>
-                        Aktiv
-                    </label>
-                </div>
             </div>
             
             <input type="hidden" name="category_id" value="<?php echo $selected_category; ?>">

--- a/admin/tabs/links-tab.php
+++ b/admin/tabs/links-tab.php
@@ -89,12 +89,12 @@ if (isset($_GET['edit_link'])) {
 }
 
 // Get all data for dropdowns (filtered by category)
-$variants = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_variants WHERE category_id = %d AND active = 1 ORDER BY sort_order, name", $selected_category));
-$extras = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_extras WHERE category_id = %d AND active = 1 ORDER BY sort_order, name", $selected_category));
-$durations = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_durations WHERE category_id = %d AND active = 1 ORDER BY sort_order, months_minimum", $selected_category));
-$conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE category_id = %d AND active = 1 ORDER BY sort_order, name", $selected_category));
-$product_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'product' AND active = 1 ORDER BY sort_order, name", $selected_category));
-$frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'frame' AND active = 1 ORDER BY sort_order, name", $selected_category));
+$variants = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_variants WHERE category_id = %d ORDER BY sort_order, name", $selected_category));
+$extras = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_extras WHERE category_id = %d ORDER BY sort_order, name", $selected_category));
+$durations = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_durations WHERE category_id = %d ORDER BY sort_order, months_minimum", $selected_category));
+$conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE category_id = %d ORDER BY sort_order, name", $selected_category));
+$product_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'product' ORDER BY sort_order, name", $selected_category));
+$frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'frame' ORDER BY sort_order, name", $selected_category));
 
 // Get all links with names (filtered by category)
 $links = $wpdb->get_results($wpdb->prepare("

--- a/admin/tabs/variants-add-tab.php
+++ b/admin/tabs/variants-add-tab.php
@@ -79,12 +79,6 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" value="0" min="0">
                 </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" checked>
-                        <span>Aktiv</span>
-                    </label>
-                </div>
             </div>
         </div>
         

--- a/admin/tabs/variants-edit-tab.php
+++ b/admin/tabs/variants-edit-tab.php
@@ -86,12 +86,6 @@
                     <label>Sortierung</label>
                     <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
                 </div>
-                <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
-                        <input type="checkbox" name="active" value="1" <?php echo $edit_item->active ? 'checked' : ''; ?>>
-                        <span>Aktiv</span>
-                    </label>
-                </div>
             </div>
         </div>
         

--- a/admin/tabs/variants-tab.php
+++ b/admin/tabs/variants-tab.php
@@ -11,7 +11,6 @@ if (isset($_POST['submit_variant'])) {
     $price_from = isset($_POST['price_from']) ? floatval($_POST['price_from']) : 0;
     $available = isset($_POST['available']) ? 1 : 0;
     $availability_note = sanitize_text_field($_POST['availability_note']);
-    $active = isset($_POST['active']) ? 1 : 0;
     $sort_order = intval($_POST['sort_order']);
     
     // Handle multiple images
@@ -30,7 +29,6 @@ if (isset($_POST['submit_variant'])) {
             'price_from' => $price_from,
             'available' => $available,
             'availability_note' => $availability_note,
-            'active' => $active,
             'sort_order' => $sort_order
         ), $image_data);
         
@@ -38,7 +36,7 @@ if (isset($_POST['submit_variant'])) {
             $table_name,
             $update_data,
             array('id' => intval($_POST['id'])),
-            array_merge(array('%d', '%s', '%s', '%f', '%f', '%d', '%s', '%d', '%d'), array_fill(0, 5, '%s')),
+            array_merge(array('%d', '%s', '%s', '%f', '%f', '%d', '%s', '%d'), array_fill(0, 5, '%s')),
             array('%d')
         );
         
@@ -55,14 +53,13 @@ if (isset($_POST['submit_variant'])) {
             'price_from' => $price_from,
             'available' => $available,
             'availability_note' => $availability_note,
-            'active' => $active,
             'sort_order' => $sort_order
         ), $image_data);
         
         $result = $wpdb->insert(
             $table_name,
             $insert_data,
-            array_merge(array('%d', '%s', '%s', '%f', '%f', '%d', '%s', '%d', '%d'), array_fill(0, 5, '%s'))
+            array_merge(array('%d', '%s', '%s', '%f', '%f', '%d', '%s', '%d'), array_fill(0, 5, '%s'))
         );
         
         if ($result !== false) {
@@ -141,12 +138,6 @@ $variants = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE c
                     <input type="number" name="sort_order" value="<?php echo $edit_item ? $edit_item->sort_order : '0'; ?>" min="0">
                 </div>
                 
-                <div class="federwiegen-form-group">
-                    <label>
-                        <input type="checkbox" name="active" value="1" <?php echo (!$edit_item || $edit_item->active) ? 'checked' : ''; ?>>
-                        Aktiv
-                    </label>
-                </div>
             </div>
             
             <!-- Images Section -->

--- a/admin/variant-options-page.php
+++ b/admin/variant-options-page.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
 global $wpdb;
 
 // Get all categories for dropdown
-$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE active = 1 ORDER BY sort_order, name");
+$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories ORDER BY sort_order, name");
 
 // Get selected category from URL parameter
 $selected_category = isset($_GET['category']) ? intval($_GET['category']) : (isset($categories[0]) ? $categories[0]->id : 1);
@@ -85,11 +85,11 @@ if (isset($_GET['edit'])) {
 $current_category = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE id = %d", $selected_category));
 
 // Get all data for dropdowns (filtered by category)
-$variants = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_variants WHERE category_id = %d AND active = 1 ORDER BY sort_order, name", $selected_category));
-$conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE category_id = %d AND active = 1 ORDER BY sort_order, name", $selected_category));
-$product_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'product' AND active = 1 ORDER BY sort_order, name", $selected_category));
-$frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'frame' AND active = 1 ORDER BY sort_order, name", $selected_category));
-$extras = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_extras WHERE category_id = %d AND active = 1 ORDER BY sort_order, name", $selected_category));
+$variants = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_variants WHERE category_id = %d ORDER BY sort_order, name", $selected_category));
+$conditions = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE category_id = %d ORDER BY sort_order, name", $selected_category));
+$product_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'product' ORDER BY sort_order, name", $selected_category));
+$frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'frame' ORDER BY sort_order, name", $selected_category));
+$extras = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}federwiegen_extras WHERE category_id = %d ORDER BY sort_order, name", $selected_category));
 
 // Get all variant options with names (filtered by category)
 $variant_options = $wpdb->get_results($wpdb->prepare("

--- a/admin/variants-page.php
+++ b/admin/variants-page.php
@@ -7,7 +7,7 @@ global $wpdb;
 $table_name = $wpdb->prefix . 'federwiegen_variants';
 
 // Get all categories for dropdown
-$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE active = 1 ORDER BY sort_order, name");
+$categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories ORDER BY sort_order, name");
 
 // Get selected category from URL parameter
 $selected_category = isset($_GET['category']) ? intval($_GET['category']) : (isset($categories[0]) ? $categories[0]->id : 1);

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -262,7 +262,6 @@ class Admin {
             $layout_style = sanitize_text_field($_POST['layout_style']);
             $duration_tooltip = sanitize_textarea_field($_POST['duration_tooltip']);
             $condition_tooltip = sanitize_textarea_field($_POST['condition_tooltip']);
-            $active = isset($_POST['active']) ? 1 : 0;
             $sort_order = intval($_POST['sort_order']);
 
             $table_name = $wpdb->prefix . 'federwiegen_categories';
@@ -294,11 +293,10 @@ class Admin {
                         'layout_style' => $layout_style,
                         'duration_tooltip' => $duration_tooltip,
                         'condition_tooltip' => $condition_tooltip,
-                        'active' => $active,
                         'sort_order' => $sort_order,
                     ],
                     ['id' => intval($_POST['id'])],
-                    array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%f','%s','%s','%s','%d','%d'),
+                    array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%f','%s','%s','%s','%d'),
                 );
 
                 if ($result !== false) {
@@ -333,10 +331,9 @@ class Admin {
                         'layout_style' => $layout_style,
                         'duration_tooltip' => $duration_tooltip,
                         'condition_tooltip' => $condition_tooltip,
-                        'active' => $active,
                         'sort_order' => $sort_order,
                     ],
-                    array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%f','%s','%s','%s','%d','%d')
+                    array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%f','%s','%s','%s','%d')
                 );
 
                 if ($result !== false) {
@@ -350,16 +347,11 @@ class Admin {
         if (isset($_GET['delete']) && isset($_GET['fw_nonce']) && wp_verify_nonce($_GET['fw_nonce'], 'federwiegen_admin_action')) {
             $category_id = intval($_GET['delete']);
             $table_name = $wpdb->prefix . 'federwiegen_categories';
-            $category_count = $wpdb->get_var("SELECT COUNT(*) FROM $table_name WHERE active = 1");
-            if ($category_count <= 1) {
-                echo '<div class="notice notice-error"><p>❌ Sie können nicht die letzte aktive Kategorie löschen!</p></div>';
+            $result = $wpdb->delete($table_name, ['id' => $category_id], ['%d']);
+            if ($result !== false) {
+                echo '<div class="notice notice-success"><p>✅ Kategorie gelöscht!</p></div>';
             } else {
-                $result = $wpdb->delete($table_name, ['id' => $category_id], ['%d']);
-                if ($result !== false) {
-                    echo '<div class="notice notice-success"><p>✅ Kategorie gelöscht!</p></div>';
-                } else {
-                    echo '<div class="notice notice-error"><p>❌ Fehler beim Löschen: ' . esc_html($wpdb->last_error) . '</p></div>';
-                }
+                echo '<div class="notice notice-error"><p>❌ Fehler beim Löschen: ' . esc_html($wpdb->last_error) . '</p></div>';
             }
         }
 
@@ -437,7 +429,7 @@ class Admin {
             }
         }
 
-        $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE active = 1 ORDER BY sort_order, name");
+        $categories = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}federwiegen_categories ORDER BY sort_order, name");
         $selected_category = isset($_GET['category']) ? intval($_GET['category']) : 0;
 
         $date_from = isset($_GET['date_from']) ? sanitize_text_field($_GET['date_from']) : date('Y-m-d', strtotime('-30 days'));

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -221,7 +221,7 @@ class Ajax {
                 switch ($option->option_type) {
                     case 'condition':
                         $condition = $wpdb->get_row($wpdb->prepare(
-                            "SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE id = %d AND active = 1",
+                            "SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE id = %d",
                             $option->option_id
                         ));
                         if ($condition) {
@@ -230,7 +230,7 @@ class Ajax {
                         break;
                     case 'product_color':
                         $color = $wpdb->get_row($wpdb->prepare(
-                            "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE id = %d AND active = 1",
+                            "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE id = %d",
                             $option->option_id
                         ));
                         if ($color) {
@@ -239,7 +239,7 @@ class Ajax {
                         break;
                     case 'frame_color':
                         $color = $wpdb->get_row($wpdb->prepare(
-                            "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE id = %d AND active = 1",
+                            "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE id = %d",
                             $option->option_id
                         ));
                         if ($color) {
@@ -248,7 +248,7 @@ class Ajax {
                         break;
                     case 'extra':
                         $extra = $wpdb->get_row($wpdb->prepare(
-                            "SELECT * FROM {$wpdb->prefix}federwiegen_extras WHERE id = %d AND active = 1",
+                            "SELECT * FROM {$wpdb->prefix}federwiegen_extras WHERE id = %d",
                             $option->option_id
                         ));
                         if ($extra) {
@@ -266,22 +266,22 @@ class Ajax {
             
             if ($variant) {
                 $conditions = $wpdb->get_results($wpdb->prepare(
-                    "SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE category_id = %d AND active = 1 ORDER BY sort_order",
+                    "SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE category_id = %d ORDER BY sort_order",
                     $variant->category_id
                 ));
                 
                 $product_colors = $wpdb->get_results($wpdb->prepare(
-                    "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'product' AND active = 1 ORDER BY sort_order",
+                    "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'product' ORDER BY sort_order",
                     $variant->category_id
                 ));
                 
                 $frame_colors = $wpdb->get_results($wpdb->prepare(
-                    "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'frame' AND active = 1 ORDER BY sort_order",
+                    "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'frame' ORDER BY sort_order",
                     $variant->category_id
                 ));
 
                 $extras = $wpdb->get_results($wpdb->prepare(
-                    "SELECT * FROM {$wpdb->prefix}federwiegen_extras WHERE category_id = %d AND active = 1 ORDER BY sort_order",
+                    "SELECT * FROM {$wpdb->prefix}federwiegen_extras WHERE category_id = %d ORDER BY sort_order",
                     $variant->category_id
                 ));
             }

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -85,14 +85,14 @@ class Plugin {
         $category = null;
         if (!empty($atts['category'])) {
             $category = $wpdb->get_row($wpdb->prepare(
-                "SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE shortcode = %s OR name = %s AND active = 1",
+                "SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE shortcode = %s OR name = %s",
                 $atts['category'],
                 $atts['category']
             ));
         }
 
         if (!$category) {
-            $category = $wpdb->get_row("SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE active = 1 ORDER BY sort_order LIMIT 1");
+            $category = $wpdb->get_row("SELECT * FROM {$wpdb->prefix}federwiegen_categories ORDER BY sort_order LIMIT 1");
         }
 
         if (!$category) {
@@ -121,13 +121,13 @@ class Plugin {
         $category = null;
         if (!empty($category_shortcode)) {
             $category = $wpdb->get_row($wpdb->prepare(
-                "SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE shortcode = %s AND active = 1",
+                "SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE shortcode = %s",
                 $category_shortcode
             ));
         }
 
         if (!$category) {
-            $category = $wpdb->get_row("SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE active = 1 ORDER BY sort_order LIMIT 1");
+            $category = $wpdb->get_row("SELECT * FROM {$wpdb->prefix}federwiegen_categories ORDER BY sort_order LIMIT 1");
         }
 
         if (!$category) {
@@ -162,13 +162,13 @@ class Plugin {
         $category = null;
         if (!empty($category_shortcode)) {
             $category = $wpdb->get_row($wpdb->prepare(
-                "SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE shortcode = %s AND active = 1",
+                "SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE shortcode = %s",
                 $category_shortcode
             ));
         }
 
         if (!$category) {
-            $category = $wpdb->get_row("SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE active = 1 ORDER BY sort_order LIMIT 1");
+            $category = $wpdb->get_row("SELECT * FROM {$wpdb->prefix}federwiegen_categories ORDER BY sort_order LIMIT 1");
         }
 
         if (!$category) {
@@ -214,13 +214,13 @@ class Plugin {
         $category = null;
         if (!empty($category_shortcode)) {
             $category = $wpdb->get_row($wpdb->prepare(
-                "SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE shortcode = %s AND active = 1",
+                "SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE shortcode = %s",
                 $category_shortcode
             ));
         }
 
         if (!$category) {
-            $category = $wpdb->get_row("SELECT * FROM {$wpdb->prefix}federwiegen_categories WHERE active = 1 ORDER BY sort_order LIMIT 1");
+            $category = $wpdb->get_row("SELECT * FROM {$wpdb->prefix}federwiegen_categories ORDER BY sort_order LIMIT 1");
         }
 
         if (!$category) {
@@ -228,7 +228,7 @@ class Plugin {
         }
 
         $variants = $wpdb->get_results($wpdb->prepare(
-            "SELECT * FROM {$wpdb->prefix}federwiegen_variants WHERE category_id = %d AND active = 1 ORDER BY base_price",
+            "SELECT * FROM {$wpdb->prefix}federwiegen_variants WHERE category_id = %d ORDER BY base_price",
             $category->id
         ));
 

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -7,17 +7,17 @@ $category_id = isset($category) ? $category->id : 1;
 
 // Get all data for this category
 $variants = $wpdb->get_results($wpdb->prepare(
-    "SELECT * FROM {$wpdb->prefix}federwiegen_variants WHERE category_id = %d AND active = 1 ORDER BY sort_order",
+    "SELECT * FROM {$wpdb->prefix}federwiegen_variants WHERE category_id = %d ORDER BY sort_order",
     $category_id
 ));
 
 $extras = $wpdb->get_results($wpdb->prepare(
-    "SELECT * FROM {$wpdb->prefix}federwiegen_extras WHERE category_id = %d AND active = 1 ORDER BY sort_order",
+    "SELECT * FROM {$wpdb->prefix}federwiegen_extras WHERE category_id = %d ORDER BY sort_order",
     $category_id
 ));
 
 $durations = $wpdb->get_results($wpdb->prepare(
-    "SELECT * FROM {$wpdb->prefix}federwiegen_durations WHERE category_id = %d AND active = 1 ORDER BY sort_order",
+    "SELECT * FROM {$wpdb->prefix}federwiegen_durations WHERE category_id = %d ORDER BY sort_order",
     $category_id
 ));
 
@@ -54,17 +54,17 @@ $condition_tooltip = isset($category) ? ($category->condition_tooltip ?? '') : '
 
 // Get initial conditions and colors (will be updated via AJAX when variant is selected)
 $initial_conditions = $wpdb->get_results($wpdb->prepare(
-    "SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE category_id = %d AND active = 1 ORDER BY sort_order",
+    "SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE category_id = %d ORDER BY sort_order",
     $category_id
 ));
 
 $initial_product_colors = $wpdb->get_results($wpdb->prepare(
-    "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'product' AND active = 1 ORDER BY sort_order",
+    "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'product' ORDER BY sort_order",
     $category_id
 ));
 
 $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
-    "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'frame' AND active = 1 ORDER BY sort_order",
+    "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'frame' ORDER BY sort_order",
     $category_id
 ));
 ?>


### PR DESCRIPTION
## Summary
- clean up admin forms to remove "Aktiv" and non-variant "Verfügbar" checkboxes
- drop all `active = 1` filters and related DB logic
- keep availability selection only for variants

## Testing
- `php` lint *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863cd380d1083309a438f1e8369aced