### PR TITLE
Add availability control for execution options

### DIFF
--- a/admin/variant-options-page.php
+++ b/admin/variant-options-page.php
@@ -23,6 +23,7 @@ if (isset($_POST['submit'])) {
     $variant_id = intval($_POST['variant_id']);
     $option_type = sanitize_text_field($_POST['option_type']);
     $option_id = intval($_POST['option_id']);
+    $available = isset($_POST['available']) ? 1 : 0;
 
     $table_name = $wpdb->prefix . 'federwiegen_variant_options';
 
@@ -33,10 +34,11 @@ if (isset($_POST['submit'])) {
             array(
                 'variant_id' => $variant_id,
                 'option_type' => $option_type,
-                'option_id' => $option_id
+                'option_id' => $option_id,
+                'available' => $available
             ),
             array('id' => intval($_POST['id'])),
-            array('%d', '%s', '%d'),
+            array('%d', '%s', '%d', '%d'),
             array('%d')
         );
         
@@ -52,9 +54,10 @@ if (isset($_POST['submit'])) {
             array(
                 'variant_id' => $variant_id,
                 'option_type' => $option_type,
-                'option_id' => $option_id
+                'option_id' => $option_id,
+                'available' => $available
             ),
-            array('%d', '%s', '%d')
+            array('%d', '%s', '%d', '%d')
         );
         
         if ($result !== false) {
@@ -229,6 +232,13 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                                         <option value="">Erst Option-Typ wählen...</option>
                                     </select>
                                 </div>
+
+                                <div class="federwiegen-form-group">
+                                    <label class="federwiegen-checkbox-label">
+                                        <input type="checkbox" name="available" value="1" checked>
+                                        <span>Verfügbar</span>
+                                    </label>
+                                </div>
                             </div>
                             
                             <div class="federwiegen-form-actions">
@@ -292,6 +302,13 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                                         <option value="">Erst Option-Typ wählen...</option>
                                     </select>
                                 </div>
+
+                                <div class="federwiegen-form-group">
+                                    <label class="federwiegen-checkbox-label">
+                                        <input type="checkbox" name="available" value="1" <?php echo ($edit_item->available ?? 1) ? 'checked' : ''; ?>>
+                                        <span>Verfügbar</span>
+                                    </label>
+                                </div>
                             </div>
                             
                             <div class="federwiegen-form-actions">
@@ -344,7 +361,7 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                                     <div style="display: flex; justify-content: space-between; align-items: center;">
                                         <div>
                                             <strong>
-                                                <?php 
+                                                <?php
                                                 switch ($option->option_type) {
                                                     case 'condition':
                                                         echo '🔄 ' . esc_html($option->option_name);
@@ -361,6 +378,11 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                                                 }
                                                 ?>
                                             </strong>
+                                            <?php if ($option->available ?? 1): ?>
+                                                <span class="federwiegen-status-badge available">✅ Verfügbar</span>
+                                            <?php else: ?>
+                                                <span class="federwiegen-status-badge unavailable">❌ Nicht verfügbar</span>
+                                            <?php endif; ?>
                                         </div>
                                         <div style="display: flex; gap: 5px;">
                                             <a href="<?php echo admin_url('admin.php?page=federwiegen-variant-options&category=' . $selected_category . '&tab=edit&edit=' . $option->id); ?>" class="button button-small">✏️</a>
@@ -381,6 +403,27 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
         ?>
     </div>
 </div>
+
+<style>
+.federwiegen-status-badge {
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 500;
+}
+
+.federwiegen-status-badge.available {
+    background: #d4edda;
+    color: #155724;
+    border: 1px solid #c3e6cb;
+}
+
+.federwiegen-status-badge.unavailable {
+    background: #f8d7da;
+    color: #721c24;
+    border: 1px solid #f5c6cb;
+}
+</style>
 
 <script>
 // Options data from PHP

--- a/assets/script.js
+++ b/assets/script.js
@@ -27,9 +27,9 @@ jQuery(document).ready(function($) {
         const type = $(this).data('type');
         const id = $(this).data('id');
 
-        // Check if variant is available
-        if (type === 'variant' && $(this).data('available') === 'false') {
-            return; // Don't allow selection of unavailable variants
+        // Prevent selection of unavailable options
+        if ($(this).data('available') === 'false') {
+            return;
         }
 
         // Remove selection from same type (except extras which allow multiple)
@@ -310,9 +310,9 @@ jQuery(document).ready(function($) {
             if (optionType === 'condition') {
                 const badgeHtml = option.price_modifier != 0 ?
                     `<span class="federwiegen-condition-badge">${option.price_modifier > 0 ? '+' : ''}${Math.round(option.price_modifier * 100)}%</span>` : '';
-                
+
                 optionHtml = `
-                    <div class="federwiegen-option" data-type="condition" data-id="${option.id}">
+                    <div class="federwiegen-option ${option.available == 0 ? 'unavailable' : ''}" data-type="condition" data-id="${option.id}" data-available="${option.available == 0 ? 'false' : 'true'}">
                         <div class="federwiegen-option-content">
                             <div class="federwiegen-condition-header">
                                 <span class="federwiegen-condition-name">${option.name}</span>
@@ -325,7 +325,7 @@ jQuery(document).ready(function($) {
                 `;
             } else if (optionType === 'product-color' || optionType === 'frame-color') {
                 optionHtml = `
-                    <div class="federwiegen-option" data-type="${optionType}" data-id="${option.id}">
+                    <div class="federwiegen-option ${option.available == 0 ? 'unavailable' : ''}" data-type="${optionType}" data-id="${option.id}" data-available="${option.available == 0 ? 'false' : 'true'}">
                         <div class="federwiegen-option-content">
                             <div class="federwiegen-color-display">
                                 <div class="federwiegen-color-preview" style="background-color: ${option.color_code};"></div>
@@ -338,7 +338,7 @@ jQuery(document).ready(function($) {
             } else if (optionType === 'extra') {
                 const priceHtml = option.price > 0 ? `+${parseFloat(option.price).toFixed(2).replace('.', ',')}€/Monat` : '';
                 optionHtml = `
-                    <div class="federwiegen-option" data-type="extra" data-id="${option.id}" data-extra-image="${option.image_url || ''}">
+                    <div class="federwiegen-option ${option.available == 0 ? 'unavailable' : ''}" data-type="extra" data-id="${option.id}" data-extra-image="${option.image_url || ''}" data-available="${option.available == 0 ? 'false' : 'true'}">
                         <div class="federwiegen-option-content">
                             <span class="federwiegen-extra-name">${option.name}</span>
                             ${priceHtml ? `<div class="federwiegen-extra-price">${priceHtml}</div>` : ''}
@@ -355,6 +355,10 @@ jQuery(document).ready(function($) {
         container.find('.federwiegen-option').on('click', function() {
             const type = $(this).data('type');
             const id = $(this).data('id');
+
+            if ($(this).data('available') === 'false') {
+                return;
+            }
 
             if (type === 'extra') {
                 $(this).toggleClass('selected');

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -206,7 +206,7 @@ class Ajax {
         
         // Get variant-specific options
         $variant_options = $wpdb->get_results($wpdb->prepare(
-            "SELECT option_type, option_id FROM {$wpdb->prefix}federwiegen_variant_options WHERE variant_id = %d",
+            "SELECT option_type, option_id, available FROM {$wpdb->prefix}federwiegen_variant_options WHERE variant_id = %d",
             $variant_id
         ));
         
@@ -225,6 +225,7 @@ class Ajax {
                             $option->option_id
                         ));
                         if ($condition) {
+                            $condition->available = intval($option->available);
                             $conditions[] = $condition;
                         }
                         break;
@@ -234,6 +235,7 @@ class Ajax {
                             $option->option_id
                         ));
                         if ($color) {
+                            $color->available = intval($option->available);
                             $product_colors[] = $color;
                         }
                         break;
@@ -243,6 +245,7 @@ class Ajax {
                             $option->option_id
                         ));
                         if ($color) {
+                            $color->available = intval($option->available);
                             $frame_colors[] = $color;
                         }
                         break;
@@ -252,6 +255,7 @@ class Ajax {
                             $option->option_id
                         ));
                         if ($extra) {
+                            $extra->available = intval($option->available);
                             $extras[] = $extra;
                         }
                         break;
@@ -269,21 +273,25 @@ class Ajax {
                     "SELECT * FROM {$wpdb->prefix}federwiegen_conditions WHERE category_id = %d ORDER BY sort_order",
                     $variant->category_id
                 ));
+                foreach ($conditions as $c) { $c->available = 1; }
                 
                 $product_colors = $wpdb->get_results($wpdb->prepare(
                     "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'product' ORDER BY sort_order",
                     $variant->category_id
                 ));
+                foreach ($product_colors as $c) { $c->available = 1; }
                 
                 $frame_colors = $wpdb->get_results($wpdb->prepare(
                     "SELECT * FROM {$wpdb->prefix}federwiegen_colors WHERE category_id = %d AND color_type = 'frame' ORDER BY sort_order",
                     $variant->category_id
                 ));
+                foreach ($frame_colors as $c) { $c->available = 1; }
 
                 $extras = $wpdb->get_results($wpdb->prepare(
                     "SELECT * FROM {$wpdb->prefix}federwiegen_extras WHERE category_id = %d ORDER BY sort_order",
                     $variant->category_id
                 ));
+                foreach ($extras as $e) { $e->available = 1; }
             }
         }
 

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -331,6 +331,13 @@ class Database {
                 $wpdb->query("ALTER TABLE $table_links ADD COLUMN $column $type AFTER duration_id");
             }
         }
+
+        // Add availability column to variant options table if it doesn't exist
+        $table_variant_options = $wpdb->prefix . 'federwiegen_variant_options';
+        $availability_column = $wpdb->get_results("SHOW COLUMNS FROM $table_variant_options LIKE 'available'");
+        if (empty($availability_column)) {
+            $wpdb->query("ALTER TABLE $table_variant_options ADD COLUMN available TINYINT(1) DEFAULT 1 AFTER option_id");
+        }
     }
     
     public function create_tables() {
@@ -503,6 +510,7 @@ class Database {
             variant_id mediumint(9) NOT NULL,
             option_type varchar(50) NOT NULL,
             option_id mediumint(9) NOT NULL,
+            available tinyint(1) DEFAULT 1,
             PRIMARY KEY (id),
             UNIQUE KEY variant_option (variant_id, option_type, option_id)
         ) $charset_collate;";

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -188,7 +188,8 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                     <div class="federwiegen-options extras layout-<?php echo esc_attr($layout_style); ?>" id="extras-container">
                         <?php foreach ($extras as $extra): ?>
                         <div class="federwiegen-option" data-type="extra" data-id="<?php echo esc_attr($extra->id); ?>"
-                             data-extra-image="<?php echo esc_attr($extra->image_url ?? ''); ?>">
+                             data-extra-image="<?php echo esc_attr($extra->image_url ?? ''); ?>"
+                             data-available="true">
                             <div class="federwiegen-option-content">
                                 <span class="federwiegen-extra-name"><?php echo esc_html($extra->name); ?></span>
                                 <?php if ($extra->price > 0): ?>
@@ -244,7 +245,7 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                     </h3>
                     <div class="federwiegen-options conditions layout-<?php echo esc_attr($layout_style); ?>">
                         <?php foreach ($initial_conditions as $condition): ?>
-                        <div class="federwiegen-option" data-type="condition" data-id="<?php echo esc_attr($condition->id); ?>">
+                        <div class="federwiegen-option" data-type="condition" data-id="<?php echo esc_attr($condition->id); ?>" data-available="true">
                             <div class="federwiegen-option-content">
                                 <div class="federwiegen-condition-header">
                                     <span class="federwiegen-condition-name"><?php echo esc_html($condition->name); ?></span>
@@ -267,7 +268,7 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                     <h3>Produktfarbe</h3>
                     <div class="federwiegen-options product-colors layout-<?php echo esc_attr($layout_style); ?>">
                         <?php foreach ($initial_product_colors as $color): ?>
-                        <div class="federwiegen-option" data-type="product-color" data-id="<?php echo esc_attr($color->id); ?>">
+                        <div class="federwiegen-option" data-type="product-color" data-id="<?php echo esc_attr($color->id); ?>" data-available="true">
                             <div class="federwiegen-option-content">
                                 <div class="federwiegen-color-display">
                                     <div class="federwiegen-color-preview" style="background-color: <?php echo esc_attr($color->color_code); ?>;"></div>
@@ -285,7 +286,7 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                     <h3>Gestellfarbe</h3>
                     <div class="federwiegen-options frame-colors layout-<?php echo esc_attr($layout_style); ?>">
                         <?php foreach ($initial_frame_colors as $color): ?>
-                        <div class="federwiegen-option" data-type="frame-color" data-id="<?php echo esc_attr($color->id); ?>">
+                        <div class="federwiegen-option" data-type="frame-color" data-id="<?php echo esc_attr($color->id); ?>" data-available="true">
                             <div class="federwiegen-option-content">
                                 <div class="federwiegen-color-display">
                                     <div class="federwiegen-color-preview" style="background-color: <?php echo esc_attr($color->color_code); ?>;"></div>


### PR DESCRIPTION
## Summary
- add `available` column to `federwiegen_variant_options`
- update database migrations for new column
- allow setting availability for variant options via admin UI
- display availability badge in variant options list
- send availability info to frontend
- prevent selection of unavailable options and mark them in templates

## Testing
- `php` not installed, so no tests run

------
https://chatgpt.com/codex/tasks/task_b_6863d68af2bc83309094bd20aae316b0