### PR TITLE
Improve color selection UI

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -19,6 +19,9 @@ jQuery(document).ready(function($) {
         currentCategoryId = container.data('category-id');
     }
 
+    // Remove old inline color labels if they exist
+    $('.federwiegen-color-name').remove();
+
     // Initialize mobile sticky price bar
     initMobileStickyPrice();
 
@@ -91,8 +94,10 @@ jQuery(document).ready(function($) {
             selectedCondition = id;
         } else if (type === 'product-color') {
             selectedProductColor = id;
+            $('#selected-product-color-name').text($(this).data('color-name'));
         } else if (type === 'frame-color') {
             selectedFrameColor = id;
+            $('#selected-frame-color-name').text($(this).data('color-name'));
         }
 
         // Update price and button state
@@ -303,6 +308,8 @@ jQuery(document).ready(function($) {
                     selectedCondition = null;
                     selectedProductColor = null;
                     selectedFrameColor = null;
+                    $('#selected-product-color-name').text('');
+                    $('#selected-frame-color-name').text('');
                     selectedExtras = [];
                     selectedDuration = null;
                     $('.federwiegen-options.durations .federwiegen-option').removeClass('selected');
@@ -349,10 +356,9 @@ jQuery(document).ready(function($) {
                 `;
             } else if (optionType === 'product-color' || optionType === 'frame-color') {
                 optionHtml = `
-                    <div class="federwiegen-option ${option.available == 0 ? 'unavailable' : ''}" data-type="${optionType}" data-id="${option.id}" data-available="${option.available == 0 ? 'false' : 'true'}">
+                    <div class="federwiegen-option ${option.available == 0 ? 'unavailable' : ''}" data-type="${optionType}" data-id="${option.id}" data-available="${option.available == 0 ? 'false' : 'true'}" data-color-name="${option.name}">
                         <div class="federwiegen-option-content">
                             <div class="federwiegen-color-display">
-                                <span class="federwiegen-color-name">Farbe: ${option.name}</span>
                                 <div class="federwiegen-color-preview" style="background-color: ${option.color_code};"></div>
                             </div>
                         </div>
@@ -370,10 +376,13 @@ jQuery(document).ready(function($) {
                     </div>
                 `;
             }
-            
+
             container.append(optionHtml);
         });
-        
+
+        // Remove any leftover inline color names
+        container.find('.federwiegen-color-name').remove();
+
         // Re-bind click events for new options
         container.find('.federwiegen-option').on('click', function() {
             const type = $(this).data('type');
@@ -405,8 +414,10 @@ jQuery(document).ready(function($) {
                     selectedCondition = id;
                 } else if (type === 'product-color') {
                     selectedProductColor = id;
+                    $('#selected-product-color-name').text($(this).data('color-name'));
                 } else if (type === 'frame-color') {
                     selectedFrameColor = id;
+                    $('#selected-frame-color-name').text($(this).data('color-name'));
                 }
             }
             

--- a/assets/style.css
+++ b/assets/style.css
@@ -374,7 +374,7 @@
 .federwiegen-options.layout-default.product-colors,
 .federwiegen-options.layout-default.frame-colors {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(40px, 1fr));
     gap: 0.5rem;
 }
 
@@ -421,7 +421,7 @@
     
     .federwiegen-options.layout-default.product-colors,
     .federwiegen-options.layout-default.frame-colors {
-        grid-template-columns: repeat(4, 1fr);
+        grid-template-columns: repeat(auto-fit, minmax(40px, 1fr));
     }
     
     .federwiegen-options.layout-grid {
@@ -436,7 +436,7 @@
     
     .federwiegen-options.layout-default.product-colors,
     .federwiegen-options.layout-default.frame-colors {
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(auto-fit, minmax(40px, 1fr));
     }
 }
 
@@ -613,9 +613,33 @@
     border-radius: 50%;
     border: 2px solid #ddd;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    position: relative;
+}
+
+.federwiegen-selected-color-name {
+    display: block;
+    font-size: 0.75rem;
+    margin-bottom: 0.25rem;
+    color: #2a372a;
+}
+
+.federwiegen-option.selected .federwiegen-color-preview {
+    border-color: #5f7f5f;
+}
+
+.federwiegen-option.unavailable .federwiegen-color-preview::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    background: #dc3232;
+    transform: rotate(45deg);
 }
 
 .federwiegen-color-name {
+    display: none;
     font-weight: 500;
     color: #2a372a;
     font-size: 0.95rem;
@@ -631,6 +655,8 @@
     box-shadow: none;
     flex-direction: column;
     align-items: center;
+    width: 40px;
+    flex: none;
 }
 
 .federwiegen-options.product-colors .federwiegen-option:hover,

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -266,12 +266,12 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                 <!-- Product Color Selection (initially populated, will be updated via AJAX) -->
                 <div class="federwiegen-section" id="product-color-section" style="<?php echo esc_attr(empty($initial_product_colors) ? 'display: none;' : ''); ?>">
                     <h3>Produktfarbe</h3>
+                    <small id="selected-product-color-name" class="federwiegen-selected-color-name"></small>
                     <div class="federwiegen-options product-colors layout-<?php echo esc_attr($layout_style); ?>">
                         <?php foreach ($initial_product_colors as $color): ?>
-                        <div class="federwiegen-option" data-type="product-color" data-id="<?php echo esc_attr($color->id); ?>" data-available="true">
+                        <div class="federwiegen-option" data-type="product-color" data-id="<?php echo esc_attr($color->id); ?>" data-available="true" data-color-name="<?php echo esc_attr($color->name); ?>">
                             <div class="federwiegen-option-content">
                                 <div class="federwiegen-color-display">
-                                    <span class="federwiegen-color-name">Farbe: <?php echo esc_html($color->name); ?></span>
                                     <div class="federwiegen-color-preview" style="background-color: <?php echo esc_attr($color->color_code); ?>;"></div>
                                 </div>
                             </div>
@@ -283,12 +283,12 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                 <!-- Frame Color Selection (initially populated, will be updated via AJAX) -->
                 <div class="federwiegen-section" id="frame-color-section" style="<?php echo esc_attr(empty($initial_frame_colors) ? 'display: none;' : ''); ?>">
                     <h3>Gestellfarbe</h3>
+                    <small id="selected-frame-color-name" class="federwiegen-selected-color-name"></small>
                     <div class="federwiegen-options frame-colors layout-<?php echo esc_attr($layout_style); ?>">
                         <?php foreach ($initial_frame_colors as $color): ?>
-                        <div class="federwiegen-option" data-type="frame-color" data-id="<?php echo esc_attr($color->id); ?>" data-available="true">
+                        <div class="federwiegen-option" data-type="frame-color" data-id="<?php echo esc_attr($color->id); ?>" data-available="true" data-color-name="<?php echo esc_attr($color->name); ?>">
                             <div class="federwiegen-option-content">
                                 <div class="federwiegen-color-display">
-                                    <span class="federwiegen-color-name">Farbe: <?php echo esc_html($color->name); ?></span>
                                     <div class="federwiegen-color-preview" style="background-color: <?php echo esc_attr($color->color_code); ?>;"></div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- show dynamic color names below Product- and Framecolor sections
- generate color options without labels and carry color name as data attribute
- highlight selected color preview and strike out unavailable previews
- compact color options with small width
- hide inline color names when options reload

## Testing
- `node -e "require('fs').readFileSync('assets/script.js')" > /dev/null && echo OK`


------
https://chatgpt.com/codex/tasks/task_b_6863e83ea6088330bd4077aa4ae9848e