### PR TITLE
Enhance admin color preview and category editor

### DIFF
--- a/admin/colors-page.php
+++ b/admin/colors-page.php
@@ -184,7 +184,10 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                                 
                                 <div class="federwiegen-form-group">
                                     <label>Farbcode *</label>
-                                    <input type="color" name="color_code" value="#FFFFFF" required>
+                                    <div class="federwiegen-color-input">
+                                        <input type="color" name="color_code" value="#FFFFFF" required>
+                                        <span class="federwiegen-color-swatch" style="background-color:#FFFFFF;"></span>
+                                    </div>
                                 </div>
                                 
                                 <div class="federwiegen-form-group">
@@ -235,7 +238,10 @@ $frame_colors = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHE
                                 
                                 <div class="federwiegen-form-group">
                                     <label>Farbcode *</label>
-                                    <input type="color" name="color_code" value="<?php echo esc_attr($edit_item->color_code); ?>" required>
+                                    <div class="federwiegen-color-input">
+                                        <input type="color" name="color_code" value="<?php echo esc_attr($edit_item->color_code); ?>" required>
+                                        <span class="federwiegen-color-swatch" style="background-color: <?php echo esc_attr($edit_item->color_code); ?>;"></span>
+                                    </div>
                                 </div>
                                 
                                 <div class="federwiegen-form-group">

--- a/admin/tabs/categories-add-tab.php
+++ b/admin/tabs/categories-add-tab.php
@@ -68,7 +68,17 @@
             
             <div class="federwiegen-form-group">
                 <label>Produktbeschreibung *</label>
-                <textarea name="product_description" rows="4" required placeholder="Beschreibungstext unter dem Produkttitel"></textarea>
+                <?php
+                wp_editor(
+                    '',
+                    'category_product_description_add',
+                    [
+                        'textarea_name' => 'product_description',
+                        'textarea_rows' => 5,
+                        'media_buttons' => false,
+                    ]
+                );
+                ?>
             </div>
         </div>
         

--- a/admin/tabs/categories-edit-tab.php
+++ b/admin/tabs/categories-edit-tab.php
@@ -70,7 +70,17 @@
             
             <div class="federwiegen-form-group">
                 <label>Produktbeschreibung *</label>
-                <textarea name="product_description" rows="4" required><?php echo esc_textarea($edit_item->product_description); ?></textarea>
+                <?php
+                wp_editor(
+                    $edit_item->product_description,
+                    'category_product_description_edit',
+                    [
+                        'textarea_name' => 'product_description',
+                        'textarea_rows' => 5,
+                        'media_buttons' => false,
+                    ]
+                );
+                ?>
             </div>
         </div>
         

--- a/assets/admin-script.js
+++ b/assets/admin-script.js
@@ -75,4 +75,17 @@ jQuery(document).ready(function($) {
             return false;
         }
     });
+
+    // Update color preview swatches
+    $('input[type="color"]').each(function() {
+        var swatch = $(this).siblings('.federwiegen-color-swatch');
+        if (swatch.length) {
+            swatch.css('background-color', $(this).val());
+        }
+    }).on('input change', function() {
+        var swatch = $(this).siblings('.federwiegen-color-swatch');
+        if (swatch.length) {
+            swatch.css('background-color', $(this).val());
+        }
+    });
 });

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -509,6 +509,22 @@
     transform: scale(1.05);
 }
 
+.federwiegen-color-swatch {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    border: 2px solid #ddd;
+    display: inline-block;
+    margin-left: 10px;
+    vertical-align: middle;
+}
+
+.federwiegen-color-input {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
 /* Form styling improvements */
 .form-table th {
     width: 200px;

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -244,7 +244,7 @@ class Admin {
             $meta_title = sanitize_text_field($_POST['meta_title']);
             $meta_description = sanitize_textarea_field($_POST['meta_description']);
             $product_title = sanitize_text_field($_POST['product_title']);
-            $product_description = sanitize_textarea_field($_POST['product_description']);
+            $product_description = wp_kses_post($_POST['product_description']);
             $default_image = esc_url_raw($_POST['default_image']);
             $features_title = sanitize_text_field($_POST['features_title']);
             $feature_1_icon = esc_url_raw($_POST['feature_1_icon']);


### PR DESCRIPTION
## Summary
- show color preview swatch while editing colors
- use WordPress editor for category description
- allow HTML in category description
- style color preview and update preview via JS

## Testing
- `php` command was unavailable so no linting could be run

------
https://chatgpt.com/codex/tasks/task_b_68642832df1483308b91099bc747acb0