### PR TITLE
Replace availability checkboxes with toggles

### DIFF
--- a/admin/tabs/variants-add-tab.php
+++ b/admin/tabs/variants-add-tab.php
@@ -41,8 +41,9 @@
             <h4>📦 Verfügbarkeit</h4>
             <div class="federwiegen-form-row">
                 <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
+                    <label class="federwiegen-toggle-label">
                         <input type="checkbox" name="available" value="1" checked>
+                        <span class="federwiegen-toggle-slider"></span>
                         <span>Verfügbar</span>
                     </label>
                 </div>
@@ -173,17 +174,12 @@
     outline: none;
 }
 
-.federwiegen-checkbox-label {
+.federwiegen-toggle-label {
     display: flex !important;
     flex-direction: row !important;
     align-items: center;
     gap: 8px;
     cursor: pointer;
-}
-
-.federwiegen-checkbox-label input[type="checkbox"] {
-    width: auto;
-    margin: 0;
 }
 
 .federwiegen-images-grid {

--- a/admin/tabs/variants-edit-tab.php
+++ b/admin/tabs/variants-edit-tab.php
@@ -42,8 +42,9 @@
             <h4>📦 Verfügbarkeit</h4>
             <div class="federwiegen-form-row">
                 <div class="federwiegen-form-group">
-                    <label class="federwiegen-checkbox-label">
+                    <label class="federwiegen-toggle-label">
                         <input type="checkbox" name="available" value="1" <?php echo ($edit_item->available ?? 1) ? 'checked' : ''; ?>>
+                        <span class="federwiegen-toggle-slider"></span>
                         <span>Verfügbar</span>
                     </label>
                 </div>

--- a/admin/tabs/variants-tab.php
+++ b/admin/tabs/variants-tab.php
@@ -122,9 +122,10 @@ $variants = $wpdb->get_results($wpdb->prepare("SELECT * FROM $table_name WHERE c
                 </div>
                 
                 <div class="federwiegen-form-group">
-                    <label>
+                    <label class="federwiegen-toggle-label">
                         <input type="checkbox" name="available" value="1" <?php echo (!$edit_item || $edit_item->available) ? 'checked' : ''; ?>>
-                        Verfügbar
+                        <span class="federwiegen-toggle-slider"></span>
+                        <span>Verfügbar</span>
                     </label>
                 </div>
                 

--- a/admin/variant-options-page.php
+++ b/admin/variant-options-page.php
@@ -234,8 +234,9 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                                 </div>
 
                                 <div class="federwiegen-form-group">
-                                    <label class="federwiegen-checkbox-label">
+                                    <label class="federwiegen-toggle-label">
                                         <input type="checkbox" name="available" value="1" checked>
+                                        <span class="federwiegen-toggle-slider"></span>
                                         <span>Verfügbar</span>
                                     </label>
                                 </div>
@@ -304,8 +305,9 @@ $variant_options = $wpdb->get_results($wpdb->prepare("
                                 </div>
 
                                 <div class="federwiegen-form-group">
-                                    <label class="federwiegen-checkbox-label">
+                                    <label class="federwiegen-toggle-label">
                                         <input type="checkbox" name="available" value="1" <?php echo ($edit_item->available ?? 1) ? 'checked' : ''; ?>>
+                                        <span class="federwiegen-toggle-slider"></span>
                                         <span>Verfügbar</span>
                                     </label>
                                 </div>

--- a/assets/admin-style.css
+++ b/assets/admin-style.css
@@ -641,3 +641,44 @@
     padding: 2px;
     background: #fff;
 }
+
+/* Toggle switch */
+.federwiegen-toggle-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+}
+
+.federwiegen-toggle-label input {
+    display: none;
+}
+
+.federwiegen-toggle-slider {
+    position: relative;
+    width: 40px;
+    height: 22px;
+    background: #ccc;
+    border-radius: 22px;
+    transition: background 0.3s;
+}
+
+.federwiegen-toggle-slider::before {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 18px;
+    height: 18px;
+    background: #fff;
+    border-radius: 50%;
+    transition: transform 0.3s;
+}
+
+.federwiegen-toggle-label input:checked + .federwiegen-toggle-slider {
+    background: #5f7f5f;
+}
+
+.federwiegen-toggle-label input:checked + .federwiegen-toggle-slider::before {
+    transform: translateX(18px);
+}


### PR DESCRIPTION
## Summary
- switch product availability checkboxes to toggle style inputs
- add global styles for the new toggle component

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68643d7cc0f08330a56ba1e6d7875719