### PR TITLE
Enhance availability notifications

### DIFF
--- a/admin/analytics-page.php
+++ b/admin/analytics-page.php
@@ -59,13 +59,17 @@ foreach ($branding_results as $result) {
     
     <!-- Tab Navigation -->
     <div class="federwiegen-tab-nav">
-        <a href="<?php echo admin_url('admin.php?page=federwiegen-analytics&category=' . $selected_category . '&tab=dashboard'); ?>" 
+        <a href="<?php echo admin_url('admin.php?page=federwiegen-analytics&category=' . $selected_category . '&tab=dashboard'); ?>"
            class="federwiegen-tab <?php echo $active_tab === 'dashboard' ? 'active' : ''; ?>">
             📊 Analytics Dashboard
         </a>
-        <a href="<?php echo admin_url('admin.php?page=federwiegen-analytics&category=' . $selected_category . '&tab=orders'); ?>" 
+        <a href="<?php echo admin_url('admin.php?page=federwiegen-analytics&category=' . $selected_category . '&tab=orders'); ?>"
            class="federwiegen-tab <?php echo $active_tab === 'orders' ? 'active' : ''; ?>">
             📋 Bestellungen
+        </a>
+        <a href="<?php echo admin_url('admin.php?page=federwiegen-analytics&category=' . $selected_category . '&tab=notifications'); ?>"
+           class="federwiegen-tab <?php echo $active_tab === 'notifications' ? 'active' : ''; ?>">
+            📧 Benachrichtigungen
         </a>
     </div>
     
@@ -78,6 +82,9 @@ foreach ($branding_results as $result) {
                 break;
             case 'orders':
                 include FEDERWIEGEN_PLUGIN_PATH . 'admin/tabs/orders-tab.php';
+                break;
+            case 'notifications':
+                include FEDERWIEGEN_PLUGIN_PATH . 'admin/tabs/notifications-tab.php';
                 break;
             default:
                 include FEDERWIEGEN_PLUGIN_PATH . 'admin/tabs/analytics-dashboard-tab.php';

--- a/admin/tabs/notifications-tab.php
+++ b/admin/tabs/notifications-tab.php
@@ -1,0 +1,123 @@
+<?php
+// Notifications Tab Content
+
+// Handle delete notification
+if (isset($_GET['delete_notification'])) {
+    $notification_id = intval($_GET['delete_notification']);
+    $result = $wpdb->delete(
+        $wpdb->prefix . 'federwiegen_notifications',
+        array('id' => $notification_id),
+        array('%d')
+    );
+
+    if ($result !== false) {
+        echo '<div class="notice notice-success"><p>✅ Eintrag erfolgreich gelöscht!</p></div>';
+    } else {
+        echo '<div class="notice notice-error"><p>❌ Fehler beim Löschen: ' . esc_html($wpdb->last_error) . '</p></div>';
+    }
+}
+
+// Handle bulk delete
+if (!empty($_POST['delete_notifications']) && is_array($_POST['delete_notifications'])) {
+    $ids = array_map('intval', (array) $_POST['delete_notifications']);
+    if ($ids) {
+        $placeholders = implode(',', array_fill(0, count($ids), '%d'));
+        $query = $wpdb->prepare(
+            "DELETE FROM {$wpdb->prefix}federwiegen_notifications WHERE id IN ($placeholders)",
+            ...$ids
+        );
+        $result = $wpdb->query($query);
+        if ($result !== false) {
+            echo '<div class="notice notice-success"><p>✅ Einträge erfolgreich gelöscht!</p></div>';
+        } else {
+            echo '<div class="notice notice-error"><p>❌ Fehler beim Löschen: ' . esc_html($wpdb->last_error) . '</p></div>';
+        }
+    }
+}
+
+$where_clause = $selected_category > 0 ? $wpdb->prepare('WHERE n.category_id = %d', $selected_category) : '';
+$notifications = $wpdb->get_results(
+    "SELECT n.*, v.name AS variant_name FROM {$wpdb->prefix}federwiegen_notifications n
+     LEFT JOIN {$wpdb->prefix}federwiegen_variants v ON n.variant_id = v.id
+     $where_clause ORDER BY n.created_at DESC"
+);
+?>
+
+<div class="federwiegen-notifications-tab">
+    <div class="federwiegen-orders-card">
+        <div class="federwiegen-orders-header">
+            <h4>📧 Benachrichtigungsanfragen</h4>
+            <?php if (!empty($notifications)): ?>
+            <div class="federwiegen-bulk-actions">
+                <button type="button" class="button" onclick="toggleSelectAllNotifications()">Alle auswählen</button>
+                <button type="button" class="button" onclick="deleteSelectedNotifications()" style="color: #dc3232;">Ausgewählte löschen</button>
+            </div>
+            <?php endif; ?>
+        </div>
+        <?php if (empty($notifications)): ?>
+            <div class="federwiegen-empty-state">
+                <p>Keine Einträge vorhanden.</p>
+            </div>
+        <?php else: ?>
+        <div style="overflow-x:auto;">
+            <table class="wp-list-table widefat fixed striped">
+                <thead>
+                    <tr>
+                        <th style="width:40px;"><input type="checkbox" id="select-all-notifications"></th>
+                        <th style="width:80px;">ID</th>
+                        <th style="width:140px;">Datum</th>
+                        <th>E-Mail</th>
+                        <th>Produkt</th>
+                        <th style="width:120px;">Aktionen</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($notifications as $note): ?>
+                    <tr>
+                        <td><input type="checkbox" class="notification-checkbox" value="<?php echo $note->id; ?>"></td>
+                        <td><strong>#<?php echo $note->id; ?></strong></td>
+                        <td><?php echo date('d.m.Y H:i', strtotime($note->created_at)); ?></td>
+                        <td><?php echo esc_html($note->email); ?></td>
+                        <td><?php echo esc_html($note->variant_name ?: ''); ?></td>
+                        <td>
+                            <a href="<?php echo admin_url('admin.php?page=federwiegen-analytics&tab=notifications&category=' . $selected_category . '&delete_notification=' . $note->id); ?>" class="button button-small" style="color:#dc3232;" onclick="return confirm('Eintrag wirklich löschen?');">🗑️ Löschen</a>
+                        </td>
+                    </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+        <?php endif; ?>
+    </div>
+</div>
+
+<script>
+function toggleSelectAllNotifications() {
+    const selectAll = document.getElementById('select-all-notifications');
+    const checkboxes = document.querySelectorAll('.notification-checkbox');
+    const allChecked = Array.from(checkboxes).every(cb => cb.checked);
+    checkboxes.forEach(cb => cb.checked = !allChecked);
+    selectAll.checked = !allChecked;
+}
+
+function deleteSelectedNotifications() {
+    const selected = Array.from(document.querySelectorAll('.notification-checkbox:checked')).map(cb => cb.value);
+    if (selected.length === 0) {
+        alert('Bitte wählen Sie mindestens einen Eintrag aus.');
+        return;
+    }
+    if (!confirm('Ausgewählte Einträge löschen?')) return;
+    const form = document.createElement('form');
+    form.method = 'POST';
+    form.action = window.location.href;
+    selected.forEach(id => {
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'delete_notifications[]';
+        input.value = id;
+        form.appendChild(input);
+    });
+    document.body.appendChild(form);
+    form.submit();
+}
+</script>

--- a/assets/script.js
+++ b/assets/script.js
@@ -33,6 +33,9 @@ jQuery(document).ready(function($) {
         // Prevent selection of unavailable options
         const available = $(this).data('available');
         if (available === false || available === 'false' || available === 0 || available === '0') {
+            if (type === 'variant') {
+                selectedVariant = id;
+            }
             $('#federwiegen-rent-button').prop('disabled', true);
             $('.federwiegen-mobile-button').prop('disabled', true);
             $('#federwiegen-button-help').hide();
@@ -40,6 +43,7 @@ jQuery(document).ready(function($) {
             $('#federwiegen-notify').show();
             $('.federwiegen-notify-form').show();
             $('#federwiegen-notify-success').hide();
+            scrollToNotify();
             return;
         }
 
@@ -519,6 +523,7 @@ jQuery(document).ready(function($) {
                             if (data.availability_note) {
                                 $('#federwiegen-unavailable-help').text(data.availability_note);
                             }
+                            scrollToNotify();
                         }
                         
                         // Update mobile sticky price
@@ -663,6 +668,13 @@ jQuery(document).ready(function($) {
         return parseFloat(price).toFixed(2).replace('.', ',');
     }
 
+    function scrollToNotify() {
+        const target = $('#federwiegen-notify');
+        if (target.length) {
+            $('html, body').animate({ scrollTop: target.offset().top - 100 }, 500);
+        }
+    }
+
     // Notify when product becomes available
     $('#federwiegen-notify-submit').on('click', function(e) {
         e.preventDefault();
@@ -675,6 +687,13 @@ jQuery(document).ready(function($) {
             data: {
                 action: 'notify_availability',
                 email: email,
+                category_id: currentCategoryId,
+                variant_id: selectedVariant,
+                extra_ids: selectedExtras.join(','),
+                duration_id: selectedDuration,
+                condition_id: selectedCondition,
+                product_color_id: selectedProductColor,
+                frame_color_id: selectedFrameColor,
                 nonce: federwiegen_ajax.nonce
             },
             success: function(response) {

--- a/federwiegen-verleih.php
+++ b/federwiegen-verleih.php
@@ -3,7 +3,7 @@
   * Plugin Name: Rent Plugin
   * Plugin URI: https://h2concepts.de
   * Description: Ein Plugin für den Verleih von Waren mit konfigurierbaren Produkten und Stripe-Integration
-  * Version: 2.0.0
+ * Version: 2.2.0
   * Author: H2 Concepts
   * License: GPL v2 or later
   * Text Domain: h2-concepts
@@ -14,7 +14,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-const FEDERWIEGEN_PLUGIN_VERSION = '2.1.0';
+const FEDERWIEGEN_PLUGIN_VERSION = '2.2.0';
 const FEDERWIEGEN_PLUGIN_DIR = __DIR__ . '/';
 define('FEDERWIEGEN_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('FEDERWIEGEN_PLUGIN_PATH', FEDERWIEGEN_PLUGIN_DIR);

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -400,7 +400,7 @@ class Ajax {
         }
     }
     
-      public function ajax_notify_availability() {
+    public function ajax_notify_availability() {
         check_ajax_referer('federwiegen_nonce', 'nonce');
 
         $email = isset($_POST['email']) ? sanitize_email($_POST['email']) : '';
@@ -408,9 +408,58 @@ class Ajax {
             wp_send_json_error('Invalid email');
         }
 
+        $variant_id       = isset($_POST['variant_id']) ? intval($_POST['variant_id']) : 0;
+        $category_id      = isset($_POST['category_id']) ? intval($_POST['category_id']) : 0;
+
+        global $wpdb;
+
+        $variant_name  = '';
+        $category_name = '';
+
+        if ($variant_id) {
+            $variant = $wpdb->get_row(
+                $wpdb->prepare(
+                    "SELECT v.name, v.category_id, c.name AS category_name FROM {$wpdb->prefix}federwiegen_variants v LEFT JOIN {$wpdb->prefix}federwiegen_categories c ON v.category_id = c.id WHERE v.id = %d",
+                    $variant_id
+                )
+            );
+            if ($variant) {
+                $variant_name  = $variant->name;
+                $category_id   = $variant->category_id;
+                $category_name = $variant->category_name;
+            }
+        }
+
+        if (!$category_name && $category_id) {
+            $category_name = $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT name FROM {$wpdb->prefix}federwiegen_categories WHERE id = %d",
+                    $category_id
+                )
+            );
+        }
+
+        // Save notification request
+        $wpdb->insert(
+            $wpdb->prefix . 'federwiegen_notifications',
+            [
+                'category_id' => $category_id,
+                'variant_id'  => $variant_id,
+                'email'       => $email
+            ],
+            ['%d', '%d', '%s']
+        );
+
         $admin_email = get_option('admin_email');
-        $subject = 'Verfügbarkeitsanfrage';
-        $message = 'Ein Kunde möchte informiert werden, sobald das Produkt wieder verfügbar ist. E-Mail: ' . $email;
+        $subject     = 'Verfügbarkeitsanfrage';
+        $message     = "Ein Kunde möchte informiert werden, sobald das Produkt wieder verfügbar ist.\n";
+        $message    .= 'E-Mail: ' . $email . "\n";
+        if ($category_name) {
+            $message .= 'Kategorie: ' . $category_name . "\n";
+        }
+        if ($variant_name) {
+            $message .= 'Ausführung: ' . $variant_name . "\n";
+        }
 
         wp_mail($admin_email, $subject, $message);
 

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -317,6 +317,28 @@ class Database {
                 }
             }
         }
+
+        // Create notifications table if it doesn't exist
+        $table_notifications = $wpdb->prefix . 'federwiegen_notifications';
+        $notifications_exists = $wpdb->get_var("SHOW TABLES LIKE '$table_notifications'");
+
+        if (!$notifications_exists) {
+            $charset_collate = $wpdb->get_charset_collate();
+            $sql = "CREATE TABLE $table_notifications (
+                id mediumint(9) NOT NULL AUTO_INCREMENT,
+                category_id mediumint(9) NOT NULL,
+                variant_id mediumint(9) DEFAULT NULL,
+                email varchar(255) NOT NULL,
+                created_at timestamp DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                KEY category_id (category_id),
+                KEY variant_id (variant_id),
+                KEY created_at (created_at)
+            ) $charset_collate;";
+
+            require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+            dbDelta($sql);
+        }
         
         // Update links table with new columns
         $table_links = $wpdb->prefix . 'federwiegen_links';
@@ -553,6 +575,22 @@ class Database {
         dbDelta($sql_colors);
         dbDelta($sql_variant_options);
         dbDelta($sql_orders);
+
+        // Notifications table
+        $table_notifications = $wpdb->prefix . 'federwiegen_notifications';
+        $sql_notifications = "CREATE TABLE $table_notifications (
+            id mediumint(9) NOT NULL AUTO_INCREMENT,
+            category_id mediumint(9) NOT NULL,
+            variant_id mediumint(9) DEFAULT NULL,
+            email varchar(255) NOT NULL,
+            created_at timestamp DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (id),
+            KEY category_id (category_id),
+            KEY variant_id (variant_id),
+            KEY created_at (created_at)
+        ) $charset_collate;";
+
+        dbDelta($sql_notifications);
     }
     
     public function insert_default_data() {


### PR DESCRIPTION
## Summary
- add availability notification storage and email details
- auto-scroll to notify form when product unavailable
- show notification requests in analytics with delete option
- create notifications table on install/update
- bump plugin version

## Testing
- `php` command not available; could not run PHP lint

------
https://chatgpt.com/codex/tasks/task_b_6864f1aff5488330986c45538f9bd0b8