### PR TITLE
Improve category settings layout

### DIFF
--- a/admin/tabs/categories-edit-tab.php
+++ b/admin/tabs/categories-edit-tab.php
@@ -15,7 +15,10 @@
         <div class="federwiegen-subtab-nav">
             <a href="#" class="federwiegen-subtab active" data-tab="general">Allgemein</a>
             <a href="#" class="federwiegen-subtab" data-tab="product">Produktseite</a>
+            <a href="#" class="federwiegen-subtab" data-tab="shipping">Versand</a>
             <a href="#" class="federwiegen-subtab" data-tab="features">Features</a>
+            <a href="#" class="federwiegen-subtab" data-tab="tooltips">Tooltips</a>
+            <a href="#" class="federwiegen-subtab" data-tab="pricing">Preis-Einstellungen</a>
         </div>
 
         <div id="tab-general" class="federwiegen-subtab-content active">
@@ -84,31 +87,6 @@
                     <label>Produkttitel *</label>
                     <input type="text" name="product_title" value="<?php echo esc_attr($edit_item->product_title); ?>" required>
                 </div>
-                <div class="federwiegen-form-group">
-                    <label>Versandkosten (€)</label>
-                    <input type="number" name="shipping_cost" value="<?php echo esc_attr($edit_item->shipping_cost); ?>" step="0.01" min="0">
-                </div>
-                <div class="federwiegen-form-group">
-                    <label>Versanddienstleister</label>
-                    <div class="federwiegen-shipping-radios">
-                        <?php $shipping_providers = [
-                            'dhl' => 'DHL',
-                            'hermes' => 'Hermes',
-                            'ups' => 'UPS',
-                            'dpd' => 'DPD'
-                        ]; ?>
-                        <?php foreach ($shipping_providers as $key => $label): ?>
-                            <label>
-                                <input type="radio" name="shipping_provider" value="<?php echo esc_attr($key); ?>" <?php checked($edit_item->shipping_provider ?? '', $key); ?>>
-                                <img src="<?php echo esc_url(FEDERWIEGEN_PLUGIN_URL . 'assets/shipping-icons/' . $key . '.svg'); ?>" alt="<?php echo esc_attr($label); ?>">
-                            </label>
-                        <?php endforeach; ?>
-                    </div>
-                </div>
-                <div class="federwiegen-form-group">
-                    <label>Text Versandkosten</label>
-                    <input type="text" name="shipping_label" value="<?php echo isset($edit_item->shipping_label) ? esc_attr($edit_item->shipping_label) : ''; ?>" placeholder="Einmalige Versandkosten:">
-                </div>
             </div>
             
             <div class="federwiegen-form-group">
@@ -146,46 +124,9 @@
             </div>
         </div>
         
-        <!-- Features -->
+        <!-- Button -->
         <div class="federwiegen-form-section">
-            <h4>🌟 Features-Sektion</h4>
-            <div class="federwiegen-form-group">
-                <label>Features-Überschrift</label>
-                <input type="text" name="features_title" value="<?php echo esc_attr($edit_item->features_title); ?>">
-            </div>
-            
-            <?php for ($i = 1; $i <= 3; $i++): ?>
-            <div class="federwiegen-feature-group">
-                <h5>Feature <?php echo $i; ?></h5>
-                <div class="federwiegen-form-row">
-                    <div class="federwiegen-form-group">
-                        <label>Titel</label>
-                        <input type="text" name="feature_<?php echo $i; ?>_title" value="<?php echo esc_attr($edit_item->{'feature_' . $i . '_title'}); ?>">
-                    </div>
-                    <div class="federwiegen-form-group">
-                        <label>Icon-Bild</label>
-                        <div class="federwiegen-upload-area">
-                            <input type="url" name="feature_<?php echo $i; ?>_icon" id="feature_<?php echo $i; ?>_icon" value="<?php echo esc_attr($edit_item->{'feature_' . $i . '_icon'}); ?>">
-                            <button type="button" class="button federwiegen-media-button" data-target="feature_<?php echo $i; ?>_icon">📁</button>
-                        </div>
-                        <?php if (!empty($edit_item->{'feature_' . $i . '_icon'})): ?>
-                        <div class="federwiegen-icon-preview">
-                            <img src="<?php echo esc_url($edit_item->{'feature_' . $i . '_icon'}); ?>" alt="Feature <?php echo $i; ?> Icon">
-                        </div>
-                        <?php endif; ?>
-                    </div>
-                </div>
-                <div class="federwiegen-form-group">
-                    <label>Beschreibung</label>
-                    <textarea name="feature_<?php echo $i; ?>_description" rows="2"><?php echo esc_textarea($edit_item->{'feature_' . $i . '_description'}); ?></textarea>
-                </div>
-            </div>
-            <?php endfor; ?>
-        </div>
-        
-        <!-- Button & Tooltips -->
-        <div class="federwiegen-form-section">
-            <h4>🔘 Button & Tooltips</h4>
+            <h4>🔘 Button</h4>
             <div class="federwiegen-form-row">
                 <div class="federwiegen-form-group">
                     <label>Button-Text</label>
@@ -202,23 +143,6 @@
                         <img src="<?php echo esc_url($edit_item->button_icon); ?>" alt="Button Icon">
                     </div>
                     <?php endif; ?>
-                </div>
-            </div>
-
-            <div class="federwiegen-form-row">
-                <div class="federwiegen-form-group">
-                    <label>Preis-Label</label>
-                    <input type="text" name="price_label" value="<?php echo isset($edit_item->price_label) ? esc_attr($edit_item->price_label) : ''; ?>" placeholder="Monatlicher Mietpreis">
-                </div>
-                <div class="federwiegen-form-group">
-                    <label>Preiszeitraum</label>
-                    <select name="price_period">
-                        <option value="month" <?php isset($edit_item->price_period) ? selected($edit_item->price_period, 'month') : ''; ?>>pro Monat</option>
-                        <option value="one-time" <?php isset($edit_item->price_period) ? selected($edit_item->price_period, 'one-time') : ''; ?>>einmalig</option>
-                    </select>
-                </div>
-                <div class="federwiegen-form-group">
-                    <label><input type="checkbox" name="vat_included" value="1" <?php isset($edit_item->vat_included) ? checked($edit_item->vat_included, 1) : ''; ?>> Mit MwSt.</label>
                 </div>
             </div>
 
@@ -250,18 +174,41 @@
                     <?php endforeach; ?>
                 </div>
             </div>
-            
-            <div class="federwiegen-form-group">
-                <label>Mietdauer-Tooltip</label>
-                <textarea name="duration_tooltip" rows="3"><?php echo esc_textarea($edit_item->duration_tooltip); ?></textarea>
-            </div>
-            
-            <div class="federwiegen-form-group">
-                <label>Zustand-Tooltip</label>
-                <textarea name="condition_tooltip" rows="4"><?php echo esc_textarea($edit_item->condition_tooltip); ?></textarea>
-            </div>
         </div>
         </div><!-- end tab-product -->
+
+        <div id="tab-shipping" class="federwiegen-subtab-content">
+            <div class="federwiegen-form-section">
+                <h4>🚚 Versand</h4>
+                <div class="federwiegen-form-row">
+                    <div class="federwiegen-form-group">
+                        <label>Versandkosten (€)</label>
+                        <input type="number" name="shipping_cost" value="<?php echo esc_attr($edit_item->shipping_cost); ?>" step="0.01" min="0">
+                    </div>
+                    <div class="federwiegen-form-group">
+                        <label>Versanddienstleister</label>
+                        <div class="federwiegen-shipping-radios">
+                            <?php $shipping_providers = [
+                                'dhl' => 'DHL',
+                                'hermes' => 'Hermes',
+                                'ups' => 'UPS',
+                                'dpd' => 'DPD'
+                            ]; ?>
+                            <?php foreach ($shipping_providers as $key => $label): ?>
+                                <label>
+                                    <input type="radio" name="shipping_provider" value="<?php echo esc_attr($key); ?>" <?php checked($edit_item->shipping_provider ?? '', $key); ?>>
+                                    <img src="<?php echo esc_url(FEDERWIEGEN_PLUGIN_URL . 'assets/shipping-icons/' . $key . '.svg'); ?>" alt="<?php echo esc_attr($label); ?>">
+                                </label>
+                            <?php endforeach; ?>
+                        </div>
+                    </div>
+                    <div class="federwiegen-form-group">
+                        <label>Text Versandkosten</label>
+                        <input type="text" name="shipping_label" value="<?php echo isset($edit_item->shipping_label) ? esc_attr($edit_item->shipping_label) : ''; ?>" placeholder="Einmalige Versandkosten:">
+                    </div>
+                </div>
+            </div>
+        </div><!-- end tab-shipping -->
 
         <div id="tab-features" class="federwiegen-subtab-content">
         <!-- Features -->
@@ -300,7 +247,44 @@
             </div>
             <?php endfor; ?>
         </div>
+
         </div><!-- end tab-features -->
+
+        <div id="tab-tooltips" class="federwiegen-subtab-content">
+            <div class="federwiegen-form-section">
+                <h4>💬 Tooltips</h4>
+                <div class="federwiegen-form-group">
+                    <label>Mietdauer-Tooltip</label>
+                    <textarea name="duration_tooltip" rows="3"><?php echo esc_textarea($edit_item->duration_tooltip); ?></textarea>
+                </div>
+                <div class="federwiegen-form-group">
+                    <label>Zustand-Tooltip</label>
+                    <textarea name="condition_tooltip" rows="4"><?php echo esc_textarea($edit_item->condition_tooltip); ?></textarea>
+                </div>
+            </div>
+        </div><!-- end tab-tooltips -->
+
+        <div id="tab-pricing" class="federwiegen-subtab-content">
+            <div class="federwiegen-form-section">
+                <h4>💲 Preiseinstellungen</h4>
+                <div class="federwiegen-form-row">
+                    <div class="federwiegen-form-group">
+                        <label>Preis-Label</label>
+                        <input type="text" name="price_label" value="<?php echo isset($edit_item->price_label) ? esc_attr($edit_item->price_label) : ''; ?>" placeholder="Monatlicher Mietpreis">
+                    </div>
+                    <div class="federwiegen-form-group">
+                        <label>Preiszeitraum</label>
+                        <select name="price_period">
+                            <option value="month" <?php isset($edit_item->price_period) ? selected($edit_item->price_period, 'month') : ''; ?>>pro Monat</option>
+                            <option value="one-time" <?php isset($edit_item->price_period) ? selected($edit_item->price_period, 'one-time') : ''; ?>>einmalig</option>
+                        </select>
+                    </div>
+                    <div class="federwiegen-form-group">
+                        <label><input type="checkbox" name="vat_included" value="1" <?php isset($edit_item->vat_included) ? checked($edit_item->vat_included, 1) : ''; ?>> Mit MwSt.</label>
+                    </div>
+                </div>
+            </div>
+        </div><!-- end tab-pricing -->
 
         <!-- Actions -->
         <div class="federwiegen-form-actions">

--- a/admin/tabs/categories-edit-tab.php
+++ b/admin/tabs/categories-edit-tab.php
@@ -11,6 +11,14 @@
     <form method="post" action="" class="federwiegen-compact-form">
         <?php wp_nonce_field('federwiegen_admin_action', 'federwiegen_admin_nonce'); ?>
         <input type="hidden" name="id" value="<?php echo esc_attr($edit_item->id); ?>">
+
+        <div class="federwiegen-subtab-nav">
+            <a href="#" class="federwiegen-subtab active" data-tab="general">Allgemein</a>
+            <a href="#" class="federwiegen-subtab" data-tab="product">Produktseite</a>
+            <a href="#" class="federwiegen-subtab" data-tab="features">Features</a>
+        </div>
+
+        <div id="tab-general" class="federwiegen-subtab-content active">
         
         <!-- Grunddaten -->
         <div class="federwiegen-form-section">
@@ -52,7 +60,21 @@
                 <textarea name="meta_description" rows="3" maxlength="160"><?php echo esc_textarea($edit_item->meta_description ?? ''); ?></textarea>
             </div>
         </div>
-        
+
+        <div class="federwiegen-form-section">
+            <h4>⚙️ Einstellungen</h4>
+            <div class="federwiegen-form-row">
+                <div class="federwiegen-form-group">
+                    <label>Sortierung</label>
+                    <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
+                </div>
+            </div>
+        </div>
+
+        </div><!-- end tab-general -->
+
+        <div id="tab-product" class="federwiegen-subtab-content">
+
         <!-- Seiteninhalte -->
         <div class="federwiegen-form-section">
             <h4>📄 Seiteninhalte</h4>
@@ -82,6 +104,10 @@
                             </label>
                         <?php endforeach; ?>
                     </div>
+                </div>
+                <div class="federwiegen-form-group">
+                    <label>Text Versandkosten</label>
+                    <input type="text" name="shipping_label" value="<?php echo isset($edit_item->shipping_label) ? esc_attr($edit_item->shipping_label) : ''; ?>" placeholder="Einmalige Versandkosten:">
                 </div>
             </div>
             
@@ -181,10 +207,6 @@
 
             <div class="federwiegen-form-row">
                 <div class="federwiegen-form-group">
-                    <label>Text Versandkosten</label>
-                    <input type="text" name="shipping_label" value="<?php echo isset($edit_item->shipping_label) ? esc_attr($edit_item->shipping_label) : ''; ?>" placeholder="Einmalige Versandkosten:">
-                </div>
-                <div class="federwiegen-form-group">
                     <label>Preis-Label</label>
                     <input type="text" name="price_label" value="<?php echo isset($edit_item->price_label) ? esc_attr($edit_item->price_label) : ''; ?>" placeholder="Monatlicher Mietpreis">
                 </div>
@@ -239,18 +261,47 @@
                 <textarea name="condition_tooltip" rows="4"><?php echo esc_textarea($edit_item->condition_tooltip); ?></textarea>
             </div>
         </div>
-        
-        <!-- Einstellungen -->
+        </div><!-- end tab-product -->
+
+        <div id="tab-features" class="federwiegen-subtab-content">
+        <!-- Features -->
         <div class="federwiegen-form-section">
-            <h4>⚙️ Einstellungen</h4>
-            <div class="federwiegen-form-row">
+            <h4>🌟 Features-Sektion</h4>
+            <div class="federwiegen-form-group">
+                <label>Features-Überschrift</label>
+                <input type="text" name="features_title" value="<?php echo esc_attr($edit_item->features_title); ?>">
+            </div>
+
+            <?php for ($i = 1; $i <= 3; $i++): ?>
+            <div class="federwiegen-feature-group">
+                <h5>Feature <?php echo $i; ?></h5>
+                <div class="federwiegen-form-row">
+                    <div class="federwiegen-form-group">
+                        <label>Titel</label>
+                        <input type="text" name="feature_<?php echo $i; ?>_title" value="<?php echo esc_attr($edit_item->{'feature_' . $i . '_title'}); ?>">
+                    </div>
+                    <div class="federwiegen-form-group">
+                        <label>Icon-Bild</label>
+                        <div class="federwiegen-upload-area">
+                            <input type="url" name="feature_<?php echo $i; ?>_icon" id="feature_<?php echo $i; ?>_icon" value="<?php echo esc_attr($edit_item->{'feature_' . $i . '_icon'}); ?>">
+                            <button type="button" class="button federwiegen-media-button" data-target="feature_<?php echo $i; ?>_icon">📁</button>
+                        </div>
+                        <?php if (!empty($edit_item->{'feature_' . $i . '_icon'})): ?>
+                        <div class="federwiegen-icon-preview">
+                            <img src="<?php echo esc_url($edit_item->{'feature_' . $i . '_icon'}); ?>" alt="Feature <?php echo $i; ?> Icon">
+                        </div>
+                        <?php endif; ?>
+                    </div>
+                </div>
                 <div class="federwiegen-form-group">
-                    <label>Sortierung</label>
-                    <input type="number" name="sort_order" value="<?php echo $edit_item->sort_order; ?>" min="0">
+                    <label>Beschreibung</label>
+                    <textarea name="feature_<?php echo $i; ?>_description" rows="2"><?php echo esc_textarea($edit_item->{'feature_' . $i . '_description'}); ?></textarea>
                 </div>
             </div>
+            <?php endfor; ?>
         </div>
-        
+        </div><!-- end tab-features -->
+
         <!-- Actions -->
         <div class="federwiegen-form-actions">
             <button type="submit" name="submit_category" class="button button-primary button-large">
@@ -287,6 +338,33 @@
     border-radius: 4px;
     margin-top: 5px;
 }
+.federwiegen-subtab-nav {
+    margin-bottom: 20px;
+    border-bottom: 1px solid #ddd;
+    display: flex;
+    gap: 10px;
+}
+.federwiegen-subtab {
+    padding: 8px 12px;
+    background: #f8f9fa;
+    border: 1px solid #ddd;
+    border-bottom: none;
+    color: #666;
+    border-radius: 6px 6px 0 0;
+    text-decoration: none;
+    cursor: pointer;
+}
+.federwiegen-subtab.active {
+    background: #5f7f5f;
+    color: #fff;
+    font-weight: 600;
+}
+.federwiegen-subtab-content {
+    display: none;
+}
+.federwiegen-subtab-content.active {
+    display: block;
+}
 </style>
 
 <script>
@@ -315,6 +393,19 @@ document.addEventListener('DOMContentLoaded', function() {
             });
             
             mediaUploader.open();
+        });
+    });
+
+    // Subtab switching
+    document.querySelectorAll('.federwiegen-subtab').forEach(function(tab) {
+        tab.addEventListener('click', function(e) {
+            e.preventDefault();
+            var target = this.getAttribute('data-tab');
+            document.querySelectorAll('.federwiegen-subtab').forEach(function(t) { t.classList.remove('active'); });
+            document.querySelectorAll('.federwiegen-subtab-content').forEach(function(c) { c.classList.remove('active'); });
+            this.classList.add('active');
+            var content = document.getElementById('tab-' + target);
+            if (content) content.classList.add('active');
         });
     });
 });


### PR DESCRIPTION
## Summary
- organize category edit page using sub-tabs
- group shipping cost fields together
- add styles and script for sub-tabs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_686519a73d348330925eb0259ba426fb