### PR TITLE
Add toggle to hide tooltips

### DIFF
--- a/admin/tabs/categories-add-tab.php
+++ b/admin/tabs/categories-add-tab.php
@@ -215,6 +215,9 @@
                 <label>Zustand-Tooltip</label>
                 <textarea name="condition_tooltip" rows="4" placeholder="Text der bei 'Zustand' angezeigt wird"></textarea>
             </div>
+            <div class="federwiegen-form-group">
+                <label><input type="checkbox" name="show_tooltips" value="1" checked> Tooltips auf Produktseite anzeigen</label>
+            </div>
         </div>
         
         <!-- Einstellungen -->

--- a/admin/tabs/categories-edit-tab.php
+++ b/admin/tabs/categories-edit-tab.php
@@ -261,6 +261,9 @@
                     <label>Zustand-Tooltip</label>
                     <textarea name="condition_tooltip" rows="4"><?php echo esc_textarea($edit_item->condition_tooltip); ?></textarea>
                 </div>
+                <div class="federwiegen-form-group">
+                    <label><input type="checkbox" name="show_tooltips" value="1" <?php checked($edit_item->show_tooltips ?? 1, 1); ?>> Tooltips auf Produktseite anzeigen</label>
+                </div>
             </div>
         </div><!-- end tab-tooltips -->
 

--- a/federwiegen-verleih.php
+++ b/federwiegen-verleih.php
@@ -3,7 +3,7 @@
   * Plugin Name: Rent Plugin
   * Plugin URI: https://h2concepts.de
   * Description: Ein Plugin für den Verleih von Waren mit konfigurierbaren Produkten und Stripe-Integration
- * Version: 2.6.0
+* Version: 2.6.1
   * Author: H2 Concepts
   * License: GPL v2 or later
   * Text Domain: h2-concepts
@@ -14,7 +14,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-const FEDERWIEGEN_PLUGIN_VERSION = '2.6.0';
+const FEDERWIEGEN_PLUGIN_VERSION = '2.6.1';
 const FEDERWIEGEN_PLUGIN_DIR = __DIR__ . '/';
 define('FEDERWIEGEN_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('FEDERWIEGEN_PLUGIN_PATH', FEDERWIEGEN_PLUGIN_DIR);

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -288,6 +288,7 @@ class Admin {
             $layout_style = sanitize_text_field($_POST['layout_style']);
             $duration_tooltip = sanitize_textarea_field($_POST['duration_tooltip']);
             $condition_tooltip = sanitize_textarea_field($_POST['condition_tooltip']);
+            $show_tooltips = isset($_POST['show_tooltips']) ? 1 : 0;
             $sort_order = intval($_POST['sort_order']);
 
             $table_name = $wpdb->prefix . 'federwiegen_categories';
@@ -325,10 +326,11 @@ class Admin {
                         'layout_style' => $layout_style,
                         'duration_tooltip' => $duration_tooltip,
                         'condition_tooltip' => $condition_tooltip,
+                        'show_tooltips' => $show_tooltips,
                         'sort_order' => $sort_order,
                     ],
                     ['id' => intval($_POST['id'])],
-                    array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%f','%s','%s','%s','%s','%d','%s','%s','%s','%d'),
+                    array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%f','%s','%s','%s','%s','%d','%s','%s','%s','%d','%d'),
                 );
 
                 if ($result !== false) {
@@ -369,9 +371,10 @@ class Admin {
                         'layout_style' => $layout_style,
                         'duration_tooltip' => $duration_tooltip,
                         'condition_tooltip' => $condition_tooltip,
+                        'show_tooltips' => $show_tooltips,
                         'sort_order' => $sort_order,
                     ],
-                    array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%f','%s','%s','%s','%s','%d','%s','%s','%s','%d')
+                    array('%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%f','%s','%s','%s','%s','%d','%s','%s','%s','%d','%d')
                 );
 
                 if ($result !== false) {

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -94,6 +94,7 @@ class Database {
                 layout_style varchar(50) DEFAULT 'default',
                 duration_tooltip text DEFAULT '',
                 condition_tooltip text DEFAULT '',
+                show_tooltips tinyint(1) DEFAULT 1,
                 active tinyint(1) DEFAULT 1,
                 sort_order int(11) DEFAULT 0,
                 PRIMARY KEY (id)
@@ -127,7 +128,8 @@ class Database {
                 'vat_included' => 'TINYINT(1) DEFAULT 0',
                 'layout_style' => 'VARCHAR(50) DEFAULT "default"',
                 'duration_tooltip' => 'TEXT',
-                'condition_tooltip' => 'TEXT'
+                'condition_tooltip' => 'TEXT',
+                'show_tooltips' => 'TINYINT(1) DEFAULT 1'
             );
             
             foreach ($new_columns as $column => $type) {
@@ -458,6 +460,7 @@ class Database {
             layout_style varchar(50) DEFAULT 'default',
             duration_tooltip text DEFAULT '',
             condition_tooltip text DEFAULT '',
+            show_tooltips tinyint(1) DEFAULT 1,
             active tinyint(1) DEFAULT 1,
             sort_order int(11) DEFAULT 0,
             PRIMARY KEY (id)
@@ -707,6 +710,7 @@ class Database {
                     'layout_style' => 'default',
                     'duration_tooltip' => '',
                     'condition_tooltip' => '',
+                    'show_tooltips' => 1,
                     'sort_order' => 0
                 )
             );

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -60,6 +60,7 @@ $layout_style = isset($category) ? ($category->layout_style ?? 'default') : 'def
 // Tooltips
 $duration_tooltip = isset($category) ? ($category->duration_tooltip ?? '') : '';
 $condition_tooltip = isset($category) ? ($category->condition_tooltip ?? '') : '';
+$show_tooltips = isset($category) ? ($category->show_tooltips ?? 1) : 1;
 
 // Get initial conditions and colors (will be updated via AJAX when variant is selected)
 $initial_conditions = $wpdb->get_results($wpdb->prepare(
@@ -231,10 +232,12 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                 <div class="federwiegen-section">
                     <h3>
                         Wählen Sie Ihre Mietdauer
+                        <?php if ($show_tooltips): ?>
                         <span class="federwiegen-tooltip">
                             ℹ️
                             <span class="federwiegen-tooltiptext"><?php echo esc_html($duration_tooltip); ?></span>
                         </span>
+                        <?php endif; ?>
                     </h3>
                     <div class="federwiegen-options durations layout-<?php echo esc_attr($layout_style); ?>">
                         <?php foreach ($durations as $duration): ?>
@@ -261,10 +264,12 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                 <div class="federwiegen-section" id="condition-section" style="<?php echo esc_attr(empty($initial_conditions) ? 'display: none;' : ''); ?>">
                     <h3>
                         Zustand
+                        <?php if ($show_tooltips): ?>
                         <span class="federwiegen-tooltip">
                             ℹ️
                             <span class="federwiegen-tooltiptext"><?php echo esc_html($condition_tooltip); ?></span>
                         </span>
+                        <?php endif; ?>
                     </h3>
                     <div class="federwiegen-options conditions layout-<?php echo esc_attr($layout_style); ?>">
                         <?php foreach ($initial_conditions as $condition): ?>


### PR DESCRIPTION
## Summary
- add a `show_tooltips` column for product categories
- let admin set tooltip visibility when adding/editing a category
- respect the new toggle on the product page

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68655ad926d88330a4d1515af6435309