### PR TITLE
Add availability and delivery indicator

### DIFF
--- a/admin/tabs/variants-add-tab.php
+++ b/admin/tabs/variants-add-tab.php
@@ -51,6 +51,10 @@
                     <label>Verfügbarkeits-Hinweis</label>
                     <input type="text" name="availability_note" placeholder="z.B. 'Wieder verfügbar ab 15.03.2024'">
                 </div>
+                <div class="federwiegen-form-group">
+                    <label>Lieferzeit-Text</label>
+                    <input type="text" name="delivery_time" placeholder="z.B. 3-5 Werktagen" value="3-5 Werktagen">
+                </div>
             </div>
         </div>
         

--- a/admin/tabs/variants-edit-tab.php
+++ b/admin/tabs/variants-edit-tab.php
@@ -52,6 +52,10 @@
                     <label>Verfügbarkeits-Hinweis</label>
                     <input type="text" name="availability_note" value="<?php echo esc_attr($edit_item->availability_note ?? ''); ?>">
                 </div>
+                <div class="federwiegen-form-group">
+                    <label>Lieferzeit-Text</label>
+                    <input type="text" name="delivery_time" value="<?php echo esc_attr($edit_item->delivery_time ?? '3-5 Werktagen'); ?>">
+                </div>
             </div>
         </div>
         

--- a/admin/tabs/variants-list-tab.php
+++ b/admin/tabs/variants-list-tab.php
@@ -74,6 +74,8 @@
                         <small>Sortierung: <?php echo $variant->sort_order; ?></small>
                         <?php if (!($variant->available ?? 1) && !empty($variant->availability_note)): ?>
                             <small class="federwiegen-availability-note"><?php echo esc_html($variant->availability_note); ?></small>
+                        <?php elseif (($variant->available ?? 1) && !empty($variant->delivery_time)): ?>
+                            <small class="federwiegen-availability-note">Lieferzeit: <?php echo esc_html($variant->delivery_time); ?></small>
                         <?php endif; ?>
                     </div>
                 </div>

--- a/admin/variants-page.php
+++ b/admin/variants-page.php
@@ -53,6 +53,7 @@ if (isset($_POST['submit'])) {
     $price_from = isset($_POST['price_from']) ? floatval($_POST['price_from']) : 0;
     $available = isset($_POST['available']) ? 1 : 0;
     $availability_note = sanitize_text_field($_POST['availability_note']);
+    $delivery_time = sanitize_text_field($_POST['delivery_time']);
     $active = isset($_POST['active']) ? 1 : 0;
     $sort_order = intval($_POST['sort_order']);
     
@@ -72,6 +73,7 @@ if (isset($_POST['submit'])) {
             'price_from' => $price_from,
             'available' => $available,
             'availability_note' => $availability_note,
+            'delivery_time' => $delivery_time,
             'active' => $active,
             'sort_order' => $sort_order
         ), $image_data);
@@ -80,7 +82,7 @@ if (isset($_POST['submit'])) {
             $table_name,
             $update_data,
             array('id' => intval($_POST['id'])),
-            array_merge(array('%d', '%s', '%s', '%f', '%f', '%d', '%s', '%d', '%d'), array_fill(0, 5, '%s')),
+            array_merge(array('%d', '%s', '%s', '%f', '%f', '%d', '%s', '%s', '%d', '%d'), array_fill(0, 5, '%s')),
             array('%d')
         );
         
@@ -99,6 +101,7 @@ if (isset($_POST['submit'])) {
             'price_from' => $price_from,
             'available' => $available,
             'availability_note' => $availability_note,
+            'delivery_time' => $delivery_time,
             'active' => $active,
             'sort_order' => $sort_order
         ), $image_data);
@@ -106,7 +109,7 @@ if (isset($_POST['submit'])) {
         $result = $wpdb->insert(
             $table_name,
             $insert_data,
-            array_merge(array('%d', '%s', '%s', '%f', '%f', '%d', '%s', '%d', '%d'), array_fill(0, 5, '%s'))
+            array_merge(array('%d', '%s', '%s', '%f', '%f', '%d', '%s', '%s', '%d', '%d'), array_fill(0, 5, '%s'))
         );
         
         if ($result !== false) {

--- a/assets/script.js
+++ b/assets/script.js
@@ -53,6 +53,10 @@ jQuery(document).ready(function($) {
             $('#federwiegen-notify').show();
             $('.federwiegen-notify-form').show();
             $('#federwiegen-notify-success').hide();
+            $('#federwiegen-availability-wrapper').show();
+            $('#federwiegen-availability-status').addClass('unavailable').removeClass('available');
+            $('#federwiegen-availability-status .status-text').text('Nicht auf Lager');
+            $('#federwiegen-delivery-box').hide();
             scrollToNotify();
             return;
         }
@@ -570,10 +574,22 @@ jQuery(document).ready(function($) {
                         // Update button based on availability
                         currentStripeLink = data.stripe_link;
                         const isAvailable = data.available !== false;
-                        
+
                         $('#federwiegen-rent-button').prop('disabled', !isAvailable);
                         $('.federwiegen-mobile-button').prop('disabled', !isAvailable);
-                        
+
+                        $('#federwiegen-availability-wrapper').show();
+                        if (isAvailable) {
+                            $('#federwiegen-availability-status').removeClass('unavailable').addClass('available');
+                            $('#federwiegen-availability-status .status-text').text('Sofort verfügbar');
+                            $('#federwiegen-delivery-time').text(data.delivery_time || '');
+                            $('#federwiegen-delivery-box').show();
+                        } else {
+                            $('#federwiegen-availability-status').addClass('unavailable').removeClass('available');
+                            $('#federwiegen-availability-status .status-text').text('Nicht auf Lager');
+                            $('#federwiegen-delivery-box').hide();
+                        }
+
                         if (isAvailable) {
                             $('#federwiegen-button-help').hide();
                             $('#federwiegen-unavailable-help').hide();
@@ -612,6 +628,8 @@ jQuery(document).ready(function($) {
             $('.federwiegen-notify-form').show();
             currentStripeLink = '#';
             currentPrice = 0;
+
+            $('#federwiegen-availability-wrapper').hide();
             
             // Hide mobile sticky price
             hideMobileStickyPrice();

--- a/assets/style.css
+++ b/assets/style.css
@@ -737,6 +737,45 @@
     padding-top: 1rem;
 }
 
+.federwiegen-availability-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.federwiegen-availability-status {
+    display: flex;
+    align-items: center;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: #4a674a;
+}
+
+.federwiegen-availability-status .status-dot {
+    width: 0.6rem;
+    height: 0.6rem;
+    border-radius: 50%;
+    margin-right: 0.4rem;
+    background: #4a674a;
+}
+
+.federwiegen-availability-status.unavailable {
+    color: #dc3232;
+}
+
+.federwiegen-availability-status.unavailable .status-dot {
+    background: #dc3232;
+}
+
+.federwiegen-delivery-box {
+    background: #e8f5e9;
+    color: #155724;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    font-size: 0.8rem;
+}
+
 .federwiegen-rent-button {
     width: 100%;
     padding: 1.3rem 1.5rem;

--- a/federwiegen-verleih.php
+++ b/federwiegen-verleih.php
@@ -3,7 +3,7 @@
   * Plugin Name: Rent Plugin
   * Plugin URI: https://h2concepts.de
   * Description: Ein Plugin für den Verleih von Waren mit konfigurierbaren Produkten und Stripe-Integration
-* Version: 2.6.1
+* Version: 2.6.2
   * Author: H2 Concepts
   * License: GPL v2 or later
   * Text Domain: h2-concepts
@@ -14,7 +14,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-const FEDERWIEGEN_PLUGIN_VERSION = '2.6.1';
+const FEDERWIEGEN_PLUGIN_VERSION = '2.6.2';
 const FEDERWIEGEN_PLUGIN_DIR = __DIR__ . '/';
 define('FEDERWIEGEN_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('FEDERWIEGEN_PLUGIN_PATH', FEDERWIEGEN_PLUGIN_DIR);

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -76,7 +76,8 @@ class Ajax {
                 'shipping_cost' => $shipping_cost,
                 'stripe_link' => $link ?: '#',
                 'available' => $variant->available ? true : false,
-                'availability_note' => $variant->availability_note ?: ''
+                'availability_note' => $variant->availability_note ?: '',
+                'delivery_time' => $variant->delivery_time ?: ''
             ));
         } else {
             wp_send_json_error('Invalid selection');

--- a/includes/Database.php
+++ b/includes/Database.php
@@ -31,7 +31,8 @@ class Database {
             'image_url_4' => 'TEXT',
             'image_url_5' => 'TEXT',
             'available' => 'TINYINT(1) DEFAULT 1',
-            'availability_note' => 'VARCHAR(255) DEFAULT ""'
+            'availability_note' => 'VARCHAR(255) DEFAULT ""',
+            'delivery_time' => 'VARCHAR(255) DEFAULT ""'
         );
         
         foreach ($columns_to_add as $column => $type) {
@@ -482,6 +483,7 @@ class Database {
             image_url_5 text,
             available tinyint(1) DEFAULT 1,
             availability_note varchar(255) DEFAULT '',
+            delivery_time varchar(255) DEFAULT '',
             active tinyint(1) DEFAULT 1,
             sort_order int(11) DEFAULT 0,
             PRIMARY KEY (id)
@@ -766,6 +768,7 @@ class Database {
                         'image_url_5' => '',
                         'available' => 1,
                         'availability_note' => '',
+                        'delivery_time' => '3-5 Werktagen',
                         'sort_order' => $index
                     )
                 );

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -174,6 +174,7 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
                              data-type="variant" 
                              data-id="<?php echo esc_attr($variant->id); ?>"
                              data-available="<?php echo esc_attr(($variant->available ?? 1) ? 'true' : 'false'); ?>"
+                             data-delivery="<?php echo esc_attr($variant->delivery_time ?? ''); ?>"
                              data-images="<?php echo esc_attr(json_encode(array(
                                  $variant->image_url_1 ?? '',
                                  $variant->image_url_2 ?? '',
@@ -327,7 +328,16 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
 
                 <!-- Rent Button -->
                 <div class="federwiegen-button-section">
-                    <?php 
+                    <div class="federwiegen-availability-wrapper" id="federwiegen-availability-wrapper" style="display:none;">
+                        <div id="federwiegen-availability-status" class="federwiegen-availability-status available">
+                            <span class="status-dot"></span>
+                            <span class="status-text">Sofort verfügbar</span>
+                        </div>
+                        <div id="federwiegen-delivery-box" class="federwiegen-delivery-box" style="display:none;">
+                            Lieferung in <span id="federwiegen-delivery-time">3-5 Werktagen</span>
+                        </div>
+                    </div>
+                    <?php
                     $required_selections = array();
                     if (!empty($variants)) $required_selections[] = 'variant';
                     if (!empty($extras)) $required_selections[] = 'extra';


### PR DESCRIPTION
## Summary
- upgrade plugin version to 2.6.2
- support `delivery_time` field for variants
- show availability indicator and delivery time on product page
- manage delivery time in variant admin forms
- update frontend styles and scripts

## Testing
- `php -l federwiegen-verleih.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_686574eff7988330bf1a2fd7b7ef80ca