### PR TITLE
Fix availability indicator and clean up duration forms

### DIFF
--- a/admin/tabs/durations-add-tab.php
+++ b/admin/tabs/durations-add-tab.php
@@ -39,10 +39,6 @@
             </div>
         </div>
         
-        <!-- Einstellungen -->
-        <div class="federwiegen-form-section">
-            <h4>⚙️ Einstellungen</h4>
-        </div>
         
         <!-- Actions -->
         <div class="federwiegen-form-actions">

--- a/admin/tabs/durations-edit-tab.php
+++ b/admin/tabs/durations-edit-tab.php
@@ -40,7 +40,6 @@
             </div>
         </div>
         
-        <!-- Einstellungen -->
         
         <!-- Actions -->
         <div class="federwiegen-form-actions">

--- a/assets/script.js
+++ b/assets/script.js
@@ -46,6 +46,7 @@ jQuery(document).ready(function($) {
             } else if (type === 'extra') {
                 selectedExtras = [id];
             }
+            $(`.federwiegen-option[data-type="${type}"]`).removeClass('selected');
             $('#federwiegen-rent-button').prop('disabled', true);
             $('.federwiegen-mobile-button').prop('disabled', true);
             $('#federwiegen-button-help').hide();
@@ -463,6 +464,7 @@ jQuery(document).ready(function($) {
                 } else if (type === 'extra') {
                     selectedExtras = [id];
                 }
+                $(`.federwiegen-option[data-type="${type}"]`).removeClass('selected');
                 $('#federwiegen-rent-button').prop('disabled', true);
                 $('.federwiegen-mobile-button').prop('disabled', true);
                 $('#federwiegen-button-help').hide();
@@ -470,6 +472,10 @@ jQuery(document).ready(function($) {
                 $('#federwiegen-notify').show();
                 $('.federwiegen-notify-form').show();
                 $('#federwiegen-notify-success').hide();
+                $('#federwiegen-availability-wrapper').show();
+                $('#federwiegen-availability-status').addClass('unavailable').removeClass('available');
+                $('#federwiegen-availability-status .status-text').text('Nicht auf Lager');
+                $('#federwiegen-delivery-box').hide();
                 scrollToNotify();
                 return;
             }


### PR DESCRIPTION
## Summary
- remove empty settings section from duration forms
- update JS to remove previous selections and change stock message when selecting an unavailable option

## Testing
- `npm test` *(fails: package.json missing)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68657bd04e608330bcac9145d1535540