### PR TITLE
Add mobile color gallery notification

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -14,6 +14,7 @@ jQuery(document).ready(function($) {
     let touchStartX = 0;
     let touchEndX = 0;
     let currentPrice = 0;
+    let colorNotificationTimeout = null;
 
     // Get category ID from container
     const container = $('.federwiegen-container');
@@ -338,6 +339,10 @@ jQuery(document).ready(function($) {
                 if (type === 'frame-color' && currentProductColorImage) index += 1;
             }
             updateVariantImages(variantOption, index);
+
+            if (colorOption && (currentProductColorImage || currentFrameColorImage)) {
+                showGalleryNotification();
+            }
         }
     }
 
@@ -704,6 +709,28 @@ jQuery(document).ready(function($) {
 
     function hideMobileStickyPrice() {
         $('#mobile-sticky-price').removeClass('show');
+    }
+
+    function showGalleryNotification() {
+        if (window.innerWidth > 768) return;
+
+        let toast = $('#federwiegen-color-toast');
+        if (!toast.length) {
+            toast = $('<div id="federwiegen-color-toast" class="federwiegen-color-toast">Ein Bild zur Farbe wurde der Produktgalerie hinzugefügt</div>');
+            $('body').append(toast);
+            toast.on('click', function() {
+                const gallery = $('#federwiegen-image-gallery');
+                if (gallery.length) {
+                    $('html, body').animate({ scrollTop: gallery.offset().top - 100 }, 500);
+                }
+            });
+        }
+
+        toast.stop(true, true).fadeIn(200);
+        clearTimeout(colorNotificationTimeout);
+        colorNotificationTimeout = setTimeout(function() {
+            toast.fadeOut(200);
+        }, 3000);
     }
 
     function submitOrder() {

--- a/assets/style.css
+++ b/assets/style.css
@@ -1005,6 +1005,21 @@
     cursor: not-allowed;
 }
 
+.federwiegen-color-toast {
+    position: fixed;
+    top: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #4a674a;
+    color: #fff;
+    padding: 8px 16px;
+    border-radius: 999px;
+    font-size: 0.9rem;
+    z-index: 1001;
+    display: none;
+    cursor: pointer;
+}
+
 @media (min-width: 769px) {
     .federwiegen-mobile-sticky-price {
         display: none !important;


### PR DESCRIPTION
## Summary
- trigger toast notification after selecting both colors
- style and animate the color toast
- update toast logic so it's shown whenever a color image is added

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68662a7761688330984d16eaeaf6fd2d