### PR TITLE
Fix Safari popup blocked when opening Stripe link

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -142,9 +142,12 @@ jQuery(document).ready(function($) {
                 product_color_id: selectedProductColor,
                 frame_color_id: selectedFrameColor
             });
-            
-            // Submit order details
-            submitOrder();
+
+            // Open popup immediately to avoid blockers
+            const stripeWindow = window.open('', '_blank');
+
+            // Submit order details and redirect when done
+            submitOrder(stripeWindow);
         }
     });
 
@@ -733,9 +736,9 @@ jQuery(document).ready(function($) {
         }, 3000);
     }
 
-    function submitOrder() {
+    function submitOrder(stripeWindow) {
         const finalPrice = currentPrice;
-        
+
         $.ajax({
             url: federwiegen_ajax.ajax_url,
             type: 'POST',
@@ -754,8 +757,14 @@ jQuery(document).ready(function($) {
             },
             success: function(response) {
                 if (response.success) {
-                    // Redirect to Stripe
-                    window.open(currentStripeLink, '_blank');
+                    // Redirect to Stripe using previously opened window
+                    if (stripeWindow) {
+                        stripeWindow.location = currentStripeLink;
+                    } else {
+                        window.open(currentStripeLink, '_blank');
+                    }
+                } else if (stripeWindow) {
+                    stripeWindow.close();
                 }
             }
         });


### PR DESCRIPTION
## Summary
- open a new window immediately on rent button click
- pass the new window into `submitOrder` so the redirect occurs after the AJAX call

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6866d1cdfb2483309165d4dd557ea0c5