### PR TITLE
Fix stripe link lookup after extras update

### DIFF
--- a/federwiegen-verleih.php
+++ b/federwiegen-verleih.php
@@ -3,7 +3,7 @@
   * Plugin Name: Rent Plugin
   * Plugin URI: https://h2concepts.de
   * Description: Ein Plugin für den Verleih von Waren mit konfigurierbaren Produkten und Stripe-Integration
-* Version: 2.6.3
+* Version: 2.6.4
   * Author: H2 Concepts
   * License: GPL v2 or later
   * Text Domain: h2-concepts
@@ -14,7 +14,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Plugin constants
-const FEDERWIEGEN_PLUGIN_VERSION = '2.6.3';
+const FEDERWIEGEN_PLUGIN_VERSION = '2.6.4';
 const FEDERWIEGEN_PLUGIN_DIR = __DIR__ . '/';
 define('FEDERWIEGEN_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('FEDERWIEGEN_PLUGIN_PATH', FEDERWIEGEN_PLUGIN_DIR);


### PR DESCRIPTION
## Summary
- handle migration for `extra_ids` in links table
- add column type `varchar(255)` for `extra_ids`
- ensure unique index on links includes `extra_ids`
- bump plugin version to 2.6.4

## Testing
- `php -l includes/Database.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6866f094fae88330aee5f8c96c5bbfee