### PR TITLE
Implement exit-intent popup

### DIFF
--- a/admin/popup-page.php
+++ b/admin/popup-page.php
@@ -1,0 +1,23 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<div class="wrap">
+    <div class="federwiegen-admin-header-compact">
+        <div class="federwiegen-admin-logo-compact">📣</div>
+        <div class="federwiegen-admin-title-compact">
+            <h1>Popup Einstellungen</h1>
+            <p>Exit-Intent Popup konfigurieren</p>
+        </div>
+    </div>
+    <div class="federwiegen-breadcrumb">
+        <a href="<?php echo admin_url('admin.php?page=federwiegen-verleih'); ?>">Dashboard</a>
+        <span>→</span>
+        <strong>Popup</strong>
+    </div>
+
+    <div class="federwiegen-tab-content">
+        <?php include FEDERWIEGEN_PLUGIN_PATH . 'admin/tabs/popup-tab.php'; ?>
+    </div>
+</div>

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -35,11 +35,15 @@ foreach ($branding_results as $result) {
     
     <!-- Tab Navigation -->
     <div class="federwiegen-tab-nav">
-        <a href="<?php echo admin_url('admin.php?page=federwiegen-settings&tab=branding'); ?>" 
+        <a href="<?php echo admin_url('admin.php?page=federwiegen-settings&tab=branding'); ?>"
            class="federwiegen-tab <?php echo $active_tab === 'branding' ? 'active' : ''; ?>">
             🎨 Branding
         </a>
-        <a href="<?php echo admin_url('admin.php?page=federwiegen-settings&tab=debug'); ?>" 
+        <a href="<?php echo admin_url('admin.php?page=federwiegen-settings&tab=popup'); ?>"
+           class="federwiegen-tab <?php echo $active_tab === 'popup' ? 'active' : ''; ?>">
+            📣 Popup
+        </a>
+        <a href="<?php echo admin_url('admin.php?page=federwiegen-settings&tab=debug'); ?>"
            class="federwiegen-tab <?php echo $active_tab === 'debug' ? 'active' : ''; ?>">
             🔧 Debug
         </a>
@@ -51,6 +55,9 @@ foreach ($branding_results as $result) {
         switch ($active_tab) {
             case 'branding':
                 include FEDERWIEGEN_PLUGIN_PATH . 'admin/tabs/branding-tab.php';
+                break;
+            case 'popup':
+                include FEDERWIEGEN_PLUGIN_PATH . 'admin/tabs/popup-tab.php';
                 break;
             case 'debug':
                 include FEDERWIEGEN_PLUGIN_PATH . 'admin/tabs/debug-tab.php';

--- a/admin/tabs/popup-tab.php
+++ b/admin/tabs/popup-tab.php
@@ -4,6 +4,8 @@
 if (isset($_POST['submit_popup'])) {
     \FederwiegenVerleih\Admin::verify_admin_action();
     $settings = [
+        'enabled' => isset($_POST['popup_enabled']) ? 1 : 0,
+        'days'    => max(1, intval($_POST['popup_days'] ?? 7)),
         'title'   => sanitize_text_field($_POST['popup_title'] ?? ''),
         'content' => wp_kses_post($_POST['popup_content'] ?? ''),
         'options' => sanitize_textarea_field($_POST['popup_options'] ?? '')
@@ -13,6 +15,8 @@ if (isset($_POST['submit_popup'])) {
 }
 
 $popup_settings = get_option('federwiegen_popup_settings', []);
+$popup_enabled = isset($popup_settings['enabled']) ? intval($popup_settings['enabled']) : 0;
+$popup_days    = isset($popup_settings['days']) ? intval($popup_settings['days']) : 7;
 $popup_title   = $popup_settings['title'] ?? '';
 $popup_content = $popup_settings['content'] ?? '';
 $popup_options = $popup_settings['options'] ?? '';
@@ -24,6 +28,16 @@ $popup_options = $popup_settings['options'] ?? '';
         <div class="federwiegen-form-section">
             <h4>📣 Popup Inhalt</h4>
             <div class="federwiegen-form-grid">
+                <div class="federwiegen-form-group">
+                    <label>
+                        <input type="checkbox" name="popup_enabled" value="1" <?php checked($popup_enabled, 1); ?>>
+                        Popup aktivieren
+                    </label>
+                </div>
+                <div class="federwiegen-form-group">
+                    <label>Nicht erneut anzeigen (Tage)</label>
+                    <input type="number" name="popup_days" min="1" value="<?php echo esc_attr($popup_days); ?>">
+                </div>
                 <div class="federwiegen-form-group">
                     <label>Titel</label>
                     <input type="text" name="popup_title" value="<?php echo esc_attr($popup_title); ?>">

--- a/admin/tabs/popup-tab.php
+++ b/admin/tabs/popup-tab.php
@@ -1,0 +1,43 @@
+<?php
+// Popup Tab Content
+
+if (isset($_POST['submit_popup'])) {
+    \FederwiegenVerleih\Admin::verify_admin_action();
+    $settings = [
+        'title'   => sanitize_text_field($_POST['popup_title'] ?? ''),
+        'content' => wp_kses_post($_POST['popup_content'] ?? ''),
+        'options' => sanitize_textarea_field($_POST['popup_options'] ?? '')
+    ];
+    update_option('federwiegen_popup_settings', $settings);
+    echo '<div class="notice notice-success"><p>✅ Popup-Einstellungen gespeichert!</p></div>';
+}
+
+$popup_settings = get_option('federwiegen_popup_settings', []);
+$popup_title   = $popup_settings['title'] ?? '';
+$popup_content = $popup_settings['content'] ?? '';
+$popup_options = $popup_settings['options'] ?? '';
+?>
+
+<div class="federwiegen-branding-tab">
+    <form method="post" action="">
+        <?php wp_nonce_field('federwiegen_admin_action', 'federwiegen_admin_nonce'); ?>
+        <div class="federwiegen-form-section">
+            <h4>📣 Popup Inhalt</h4>
+            <div class="federwiegen-form-grid">
+                <div class="federwiegen-form-group">
+                    <label>Titel</label>
+                    <input type="text" name="popup_title" value="<?php echo esc_attr($popup_title); ?>">
+                </div>
+                <div class="federwiegen-form-group full-width">
+                    <label>Text</label>
+                    <?php wp_editor($popup_content, 'popup_content', ['textarea_name' => 'popup_content']); ?>
+                </div>
+                <div class="federwiegen-form-group full-width">
+                    <label>Auswahloptionen (optional, eine pro Zeile)</label>
+                    <textarea name="popup_options" rows="4" placeholder="Option 1\nOption 2\nOption 3"><?php echo esc_textarea($popup_options); ?></textarea>
+                </div>
+            </div>
+        </div>
+        <?php submit_button('💾 Einstellungen speichern', 'primary', 'submit_popup'); ?>
+    </form>
+</div>

--- a/assets/script.js
+++ b/assets/script.js
@@ -831,4 +831,42 @@ jQuery(document).ready(function($) {
             }
         });
     });
+
+    // Exit intent popup
+    let exitShown = false;
+    const popupData = federwiegen_ajax.popup_settings || {};
+    const popup = $('#federwiegen-exit-popup');
+    if (popup.length && popupData.title) {
+        $('#federwiegen-exit-title').text(popupData.title);
+        $('#federwiegen-exit-message').html(popupData.content);
+        if (popupData.options && popupData.options.length) {
+            popupData.options.forEach(opt => {
+                $('#federwiegen-exit-select').append(`<option value="${opt}">${opt}</option>`);
+            });
+            $('#federwiegen-exit-select-wrapper').show();
+            $('#federwiegen-exit-send').show();
+        }
+
+        $(document).on('mouseleave', function(e){
+            if (!exitShown && e.clientY <= 0) {
+                popup.show();
+                exitShown = true;
+            }
+        });
+
+        $('.federwiegen-exit-popup-close').on('click', function(){
+            popup.hide();
+        });
+
+        $('#federwiegen-exit-send').on('click', function(){
+            const opt = $('#federwiegen-exit-select').val() || '';
+            $.post(federwiegen_ajax.ajax_url, {
+                action: 'exit_intent_feedback',
+                option: opt,
+                nonce: federwiegen_ajax.nonce
+            }, function(){
+                popup.hide();
+            });
+        });
+    }
 });

--- a/assets/script.js
+++ b/assets/script.js
@@ -875,6 +875,7 @@ jQuery(document).ready(function($) {
 
         if (window.matchMedia('(max-width: 768px)').matches) {
             let lastScroll = window.scrollY;
+            let downEnough = lastScroll > 300;
             let inactivityTimer;
             const limit = 60000;
 
@@ -889,7 +890,9 @@ jQuery(document).ready(function($) {
 
             $(window).on('scroll', function(){
                 const current = window.scrollY;
-                if (!exitShown && lastScroll - current > 100 && current < 80) {
+                if (current > lastScroll && current > 300) {
+                    downEnough = true;
+                } else if (!exitShown && downEnough && lastScroll - current > 50 && current < 150) {
                     showPopup();
                 }
                 lastScroll = current;

--- a/assets/script.js
+++ b/assets/script.js
@@ -852,12 +852,14 @@ jQuery(document).ready(function($) {
         $(document).on('mouseleave', function(e){
             if (!exitShown && e.clientY <= 0) {
                 popup.css('display', 'flex');
+                $('body').addClass('federwiegen-popup-open');
                 exitShown = true;
             }
         });
 
         function hidePopup() {
             popup.hide();
+            $('body').removeClass('federwiegen-popup-open');
             const days = parseInt(popupData.days || '7', 10);
             const expire = Date.now() + days * 86400000;
             localStorage.setItem('federwiegen_exit_hide_until', expire.toString());

--- a/assets/script.js
+++ b/assets/script.js
@@ -836,6 +836,9 @@ jQuery(document).ready(function($) {
     let exitShown = false;
     const popupData = federwiegen_ajax.popup_settings || {};
     const popup = $('#federwiegen-exit-popup');
+    if (popup.length) {
+        popup.appendTo('body');
+    }
     const hideUntil = parseInt(localStorage.getItem('federwiegen_exit_hide_until') || '0', 10);
 
     if (popup.length && popupData.enabled && popupData.title && Date.now() > hideUntil) {

--- a/assets/style.css
+++ b/assets/style.css
@@ -1144,9 +1144,10 @@
 /* Exit Intent Popup */
 .federwiegen-exit-popup {
     position: fixed;
-    inset: 0;
-    width: 100%;
-    height: 100%;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
     background: rgba(0,0,0,0.6);
     display: flex;
     align-items: center;

--- a/assets/style.css
+++ b/assets/style.css
@@ -1146,13 +1146,15 @@
     position: fixed;
     top: 0;
     left: 0;
-    right: 0;
-    bottom: 0;
+    width: 100vw;
+    height: 100vh;
     background: rgba(0,0,0,0.6);
     display: flex;
     align-items: center;
     justify-content: center;
     z-index: 9999;
+    padding: 20px;
+    box-sizing: border-box;
 }
 
 .federwiegen-exit-popup-content {

--- a/assets/style.css
+++ b/assets/style.css
@@ -1140,3 +1140,52 @@
     width: calc(var(--rating) / 5 * 100%);
     overflow: hidden;
 }
+
+/* Exit Intent Popup */
+.federwiegen-exit-popup {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0,0,0,0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 9999;
+}
+
+.federwiegen-exit-popup-content {
+    position: relative;
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    max-width: 500px;
+    width: 90%;
+    text-align: center;
+}
+
+.federwiegen-exit-popup-close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: none;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+}
+
+.federwiegen-exit-popup-content select {
+    width: 100%;
+    padding: 8px;
+    margin: 10px 0;
+}
+
+.federwiegen-exit-popup-content button {
+    background: #5f7f5f;
+    color: #fff;
+    border: none;
+    padding: 8px 16px;
+    border-radius: 4px;
+    cursor: pointer;
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -1181,6 +1181,9 @@
     width: 100%;
     padding: 8px;
     margin: 10px 0;
+    min-height: 40px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
 }
 
 .federwiegen-exit-popup-content button {
@@ -1194,4 +1197,11 @@
 
 body.federwiegen-popup-open {
     overflow: hidden;
+}
+
+@media (max-width: 768px) {
+    .federwiegen-exit-popup-content select {
+        font-size: 1rem;
+        padding: 12px;
+    }
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -1144,10 +1144,9 @@
 /* Exit Intent Popup */
 .federwiegen-exit-popup {
     position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
+    inset: 0;
+    width: 100%;
+    height: 100%;
     background: rgba(0,0,0,0.6);
     display: flex;
     align-items: center;
@@ -1190,4 +1189,8 @@
     padding: 8px 16px;
     border-radius: 4px;
     cursor: pointer;
+}
+
+body.federwiegen-popup-open {
+    overflow: hidden;
 }

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -169,6 +169,8 @@ class Admin {
             $opts = array_filter(array_map('trim', explode("\n", $popup_settings['options'])));
             $options = array_values($opts);
         }
+        $popup_enabled = isset($popup_settings['enabled']) ? intval($popup_settings['enabled']) : 0;
+        $popup_days    = isset($popup_settings['days']) ? intval($popup_settings['days']) : 7;
 
         wp_localize_script('federwiegen-script', 'federwiegen_ajax', array(
             'ajax_url' => admin_url('admin-ajax.php'),
@@ -177,7 +179,9 @@ class Admin {
             'price_label' => $category->price_label ?? 'Monatlicher Mietpreis',
             'vat_included' => isset($category->vat_included) ? intval($category->vat_included) : 0,
             'popup_settings' => array(
-                'title' => $popup_settings['title'] ?? '',
+                'enabled' => $popup_enabled,
+                'days'    => $popup_days,
+                'title'   => $popup_settings['title'] ?? '',
                 'content' => wpautop($popup_settings['content'] ?? ''),
                 'options' => $options
             )

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -108,6 +108,15 @@ class Admin {
             'federwiegen-analytics',
             array($this, 'analytics_page')
         );
+
+        add_submenu_page(
+            'federwiegen-verleih',
+            'Popup',
+            'Popup',
+            'manage_options',
+            'federwiegen-popup',
+            array($this, 'popup_page')
+        );
         
         add_submenu_page(
             'federwiegen-verleih',
@@ -154,12 +163,24 @@ class Admin {
             $category = $wpdb->get_row("SELECT * FROM {$wpdb->prefix}federwiegen_categories ORDER BY sort_order LIMIT 1");
         }
 
+        $popup_settings = get_option('federwiegen_popup_settings', []);
+        $options = [];
+        if (!empty($popup_settings['options'])) {
+            $opts = array_filter(array_map('trim', explode("\n", $popup_settings['options'])));
+            $options = array_values($opts);
+        }
+
         wp_localize_script('federwiegen-script', 'federwiegen_ajax', array(
             'ajax_url' => admin_url('admin-ajax.php'),
             'nonce' => wp_create_nonce('federwiegen_nonce'),
             'price_period' => $category->price_period ?? 'month',
             'price_label' => $category->price_label ?? 'Monatlicher Mietpreis',
-            'vat_included' => isset($category->vat_included) ? intval($category->vat_included) : 0
+            'vat_included' => isset($category->vat_included) ? intval($category->vat_included) : 0,
+            'popup_settings' => array(
+                'title' => $popup_settings['title'] ?? '',
+                'content' => wpautop($popup_settings['content'] ?? ''),
+                'options' => $options
+            )
         ));
     }
     
@@ -550,8 +571,12 @@ class Admin {
     public function branding_page() {
         include FEDERWIEGEN_PLUGIN_PATH . 'admin/branding-page.php';
     }
-    
+
     public function debug_page() {
         include FEDERWIEGEN_PLUGIN_PATH . 'admin/debug-page.php';
+    }
+
+    public function popup_page() {
+        include FEDERWIEGEN_PLUGIN_PATH . 'admin/popup-page.php';
     }
 }

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -716,5 +716,21 @@ class Ajax {
 
         wp_send_json_success();
     }
-    
+
+    public function ajax_exit_intent_feedback() {
+        check_ajax_referer('federwiegen_nonce', 'nonce');
+
+        $option = isset($_POST['option']) ? sanitize_text_field($_POST['option']) : '';
+
+        $admins = get_users(['role' => 'administrator']);
+        $emails = wp_list_pluck($admins, 'user_email');
+
+        if (!empty($emails)) {
+            $subject = 'Exit-Intent Feedback';
+            $message = 'Kundenrückmeldung: ' . $option;
+            wp_mail($emails, $subject, $message);
+        }
+
+        wp_send_json_success();
+    }
 }

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -720,14 +720,94 @@ class Ajax {
     public function ajax_exit_intent_feedback() {
         check_ajax_referer('federwiegen_nonce', 'nonce');
 
-        $option = isset($_POST['option']) ? sanitize_text_field($_POST['option']) : '';
+        $option          = isset($_POST['option']) ? sanitize_text_field($_POST['option']) : '';
+        $variant_id      = isset($_POST['variant_id']) ? intval($_POST['variant_id']) : 0;
+        $extra_ids_raw   = isset($_POST['extra_ids']) ? sanitize_text_field($_POST['extra_ids']) : '';
+        $extra_ids_array = array_filter(array_map('intval', explode(',', $extra_ids_raw)));
+        $duration_id     = isset($_POST['duration_id']) ? intval($_POST['duration_id']) : 0;
+        $condition_id    = isset($_POST['condition_id']) ? intval($_POST['condition_id']) : 0;
+        $product_color_id = isset($_POST['product_color_id']) ? intval($_POST['product_color_id']) : 0;
+        $frame_color_id   = isset($_POST['frame_color_id']) ? intval($_POST['frame_color_id']) : 0;
+
+        global $wpdb;
+
+        $variant_name       = '';
+        $duration_name      = '';
+        $condition_name     = '';
+        $product_color_name = '';
+        $frame_color_name   = '';
+        $extras_names       = '';
+
+        if ($variant_id) {
+            $variant_name = $wpdb->get_var($wpdb->prepare(
+                "SELECT name FROM {$wpdb->prefix}federwiegen_variants WHERE id = %d",
+                $variant_id
+            ));
+        }
+
+        if ($duration_id) {
+            $duration_name = $wpdb->get_var($wpdb->prepare(
+                "SELECT name FROM {$wpdb->prefix}federwiegen_durations WHERE id = %d",
+                $duration_id
+            ));
+        }
+
+        if ($condition_id) {
+            $condition_name = $wpdb->get_var($wpdb->prepare(
+                "SELECT name FROM {$wpdb->prefix}federwiegen_conditions WHERE id = %d",
+                $condition_id
+            ));
+        }
+
+        if ($product_color_id) {
+            $product_color_name = $wpdb->get_var($wpdb->prepare(
+                "SELECT name FROM {$wpdb->prefix}federwiegen_colors WHERE id = %d",
+                $product_color_id
+            ));
+        }
+
+        if ($frame_color_id) {
+            $frame_color_name = $wpdb->get_var($wpdb->prepare(
+                "SELECT name FROM {$wpdb->prefix}federwiegen_colors WHERE id = %d",
+                $frame_color_id
+            ));
+        }
+
+        if (!empty($extra_ids_array)) {
+            $placeholders = implode(',', array_fill(0, count($extra_ids_array), '%d'));
+            $extras_names = $wpdb->get_col(
+                $wpdb->prepare(
+                    "SELECT name FROM {$wpdb->prefix}federwiegen_extras WHERE id IN ($placeholders)",
+                    ...$extra_ids_array
+                )
+            );
+            $extras_names = implode(', ', $extras_names);
+        }
 
         $admins = get_users(['role' => 'administrator']);
         $emails = wp_list_pluck($admins, 'user_email');
 
         if (!empty($emails)) {
             $subject = 'Exit-Intent Feedback';
-            $message = 'Kundenrückmeldung: ' . $option;
+            $message = "Kundenrückmeldung: $option\n";
+            if ($variant_name) {
+                $message .= 'Ausführung: ' . $variant_name . "\n";
+            }
+            if ($duration_name) {
+                $message .= 'Mietdauer: ' . $duration_name . "\n";
+            }
+            if ($condition_name) {
+                $message .= 'Zustand: ' . $condition_name . "\n";
+            }
+            if ($product_color_name) {
+                $message .= 'Produktfarbe: ' . $product_color_name . "\n";
+            }
+            if ($frame_color_name) {
+                $message .= 'Gestellfarbe: ' . $frame_color_name . "\n";
+            }
+            if ($extras_names) {
+                $message .= 'Extras: ' . $extras_names . "\n";
+            }
             wp_mail($emails, $subject, $message);
         }
 

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -40,6 +40,9 @@ class Plugin {
         add_action('wp_ajax_notify_availability', [$this->ajax, 'ajax_notify_availability']);
         add_action('wp_ajax_nopriv_notify_availability', [$this->ajax, 'ajax_notify_availability']);
 
+        add_action('wp_ajax_exit_intent_feedback', [$this->ajax, 'ajax_exit_intent_feedback']);
+        add_action('wp_ajax_nopriv_exit_intent_feedback', [$this->ajax, 'ajax_exit_intent_feedback']);
+
         add_filter('admin_footer_text', [$this->admin, 'custom_admin_footer']);
         add_action('admin_head', [$this->admin, 'custom_admin_styles']);
     }

--- a/templates/product-page.php
+++ b/templates/product-page.php
@@ -442,3 +442,15 @@ $initial_frame_colors = $wpdb->get_results($wpdb->prepare(
         </div>
     </div>
 </div>
+
+<div id="federwiegen-exit-popup" class="federwiegen-exit-popup" style="display:none;">
+    <div class="federwiegen-exit-popup-content">
+        <button type="button" class="federwiegen-exit-popup-close">&times;</button>
+        <h3 id="federwiegen-exit-title"></h3>
+        <div id="federwiegen-exit-message"></div>
+        <div id="federwiegen-exit-select-wrapper" style="display:none;">
+            <select id="federwiegen-exit-select"></select>
+        </div>
+        <button id="federwiegen-exit-send" style="display:none;">Senden</button>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add configurable exit popup tab in settings
- create popup settings page and hook it into admin menu
- localize popup settings for JS
- handle exit feedback with Ajax
- show popup on exit intent with JS and styles

## Testing
- `php -l admin/tabs/popup-tab.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686774820160833089e39db5f75fbc57